### PR TITLE
8241594: Lanai: javax/swing/JFileChooser/8013442: SIGSEGV at AMDMTLBr…

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLTexurePool.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLTexurePool.m
@@ -186,6 +186,7 @@
 
             id <MTLTexture> tex = [[self.device newTextureWithDescriptor:textureDescriptor] autorelease];
             minDeltaTpi = [[[MTLTexturePoolItem alloc] initWithTexture:tex] autorelease];
+            minDeltaTpi.isMultiSample = isMultiSample;
             NSMutableArray * cell = _cells[cellY0 * _poolCellWidth + cellX0];
             if (cell == NULL) {
                 cell = [[NSMutableArray arrayWithCapacity:10] retain];


### PR DESCRIPTION
…onzeDriver/AppleIntelHD5000GraphicsMTLDriver

Corrected MTLTexturePool logic related to creation of MultiSample textures
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8241594](https://bugs.openjdk.java.net/browse/JDK-8241594): Lanai: javax/swing/JFileChooser/8013442: SIGSEGV at AMDMTLBronzeDriver/AppleIntelHD5000GraphicsMTLDriver


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/17/head:pull/17`
`$ git checkout pull/17`
