### PR TITLE
8243545: don't use clip rect in texture-mode (in IsoBlit)

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
@@ -41,8 +41,10 @@
 
 #import <Accelerate/Accelerate.h>
 
-//#define TRACE_ISOBLIT
-//#define TRACE_BLIT
+#ifdef DEBUG
+#define TRACE_ISOBLIT
+#define TRACE_BLIT
+#endif //DEBUG
 //#define DEBUG_ISOBLIT
 //#define DEBUG_BLIT
 
@@ -347,6 +349,8 @@ jboolean clipDestCoords(
     }
     if (*dx2 <= dcx1 || *dx1 >= dcx2 || *dy2 <= dcy1 || *dy1 >= dcy2) {
         J2dTraceLn(J2D_TRACE_INFO, "\tclipDestCoords: dest rect doesn't intersect clip area");
+        J2dTraceLn4(J2D_TRACE_INFO, "\tdx2=%1.4f <= dcx1=%1.4f || *dx1=%1.4f >= dcx2=%1.4f", *dx2, dcx1, *dx1, dcx2);
+        J2dTraceLn4(J2D_TRACE_INFO, "\t*dy2=%1.4f <= dcy1=%1.4f || *dy1=%1.4f >= dcy2=%1.4f", *dy2, dcy1, *dy1, dcy2);
         return JNI_FALSE;
     }
     if (*dx1 < dcx1) {
@@ -419,7 +423,7 @@ MTLBlitLoops_IsoBlit(JNIEnv *env,
     clipDestCoords(
             &dx1, &dy1, &dx2, &dy2,
             &sx1, &sy1, &sx2, &sy2,
-            dstTex.width, dstTex.height, [mtlc.clip getRect]
+            dstTex.width, dstTex.height, texture ? NULL : [mtlc.clip getRect]
     );
 
     SurfaceDataBounds bounds;

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
@@ -227,6 +227,7 @@ extern void initSamplers(id<MTLDevice> device);
 }
 
 - (void)setClipRectX1:(jint)x1 Y1:(jint)y1 X2:(jint)x2 Y2:(jint)y2 {
+    J2dTraceLn4(J2D_TRACE_INFO, "MTLContext.setClipRect: %d,%d - %d,%d", x1, y1, x2, y2);
     [_clip setClipRectX1:x1 Y1:y1 X2:x2 Y2:y2];
 }
 


### PR DESCRIPTION
also add logging

fixed:
JDK-8243545 Nimbus L&F - SwingSet2 - Highlighted/Focused button has UI artifact
JDK-8243546 Nimbus L&F - SwingSet2 - Slider Demo - vertical slider is not rendered properly
JDK-8243542 Nimbus L&F - SwingSet2 - Internal Frames Demo - Frame dragging result in some artifacts. Recovers on window refresh
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8243545](https://bugs.openjdk.java.net/browse/JDK-8243545): Nimbus L&F - SwingSet2 - Highlighted/Focused button has UI artifact


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/43/head:pull/43`
`$ git checkout pull/43`
