### PR TITLE
8245693: Lanai: [_MTLCommandEncoder dealloc]:70: failed assertion `Co…

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.h
@@ -43,7 +43,6 @@
     id<MTLTexture> buffer;
     id<CAMetalDrawable> mtlDrawable;
     id<MTLCommandBuffer> blitCommandBuf;
-    id<MTLBlitCommandEncoder> blitEncoder;
     int topInset;
     int leftInset;
 }
@@ -55,7 +54,6 @@
 @property (readwrite, assign) id<MTLTexture> buffer;
 @property (readwrite, assign) id<CAMetalDrawable> mtlDrawable;
 @property (readwrite, assign) id<MTLCommandBuffer> blitCommandBuf;
-@property (readwrite, assign) id<MTLBlitCommandEncoder> blitEncoder;
 @property (readwrite, assign) int topInset;
 @property (readwrite, assign) int leftInset;
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.m
@@ -29,8 +29,6 @@
 #import "LWCToolkit.h"
 #import "MTLSurfaceData.h"
 
-#import "MTLBlitLoops.h"
-
 @implementation MTLLayer
 
 
@@ -41,7 +39,6 @@
 @synthesize buffer;
 @synthesize mtlDrawable;
 @synthesize blitCommandBuf;
-@synthesize blitEncoder;
 @synthesize topInset;
 @synthesize leftInset;
 
@@ -77,12 +74,14 @@
 
 - (void) blitTexture {
     @autoreleasepool {
-        [self.blitEncoder
+        id <MTLBlitCommandEncoder> blitEncoder = [self.blitCommandBuf blitCommandEncoder];
+
+        [blitEncoder
                 copyFromTexture:self.buffer sourceSlice:0 sourceLevel:0
                 sourceOrigin:MTLOriginMake((jint)(self.leftInset*self.contentsScale), (jint)(self.topInset*self.contentsScale), 0)
                 sourceSize:MTLSizeMake(self.buffer.width, self.buffer.height, 1)
                 toTexture:self.mtlDrawable.texture destinationSlice:0 destinationLevel:0 destinationOrigin:MTLOriginMake(0, 0, 0)];
-        [self.blitEncoder endEncoding];
+        [blitEncoder endEncoding];
 
         [self.blitCommandBuf presentDrawable:self.mtlDrawable];
 
@@ -123,12 +122,6 @@
     self.blitCommandBuf = [self.ctx createBlitCommandBuffer];
     if (self.blitCommandBuf == nil) {
         J2dTraceLn(J2D_TRACE_VERBOSE, "MTLLayer.initBlit: nothing to do (commandBuf is null)");
-        return;
-    }
-
-    self.blitEncoder = [self.blitCommandBuf blitCommandEncoder];
-    if (self.blitEncoder == nil) {
-        J2dTraceLn(J2D_TRACE_VERBOSE, "MTLLayer.initBlit: blitEncoder is null)");
         return;
     }
 


### PR DESCRIPTION
…mmand encoder released without endEncoding'

Create encoder in [MTLLayer blitTexture] to allow asynchronous processing in metal
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8245693](https://bugs.openjdk.java.net/browse/JDK-8245693): Lanai: [_MTLCommandEncoder dealloc]:70: failed assertion `Command encoder released without endEncoding' ⚠️ Title mismatch between PR and JBS.


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/46/head:pull/46`
`$ git checkout pull/46`
