### PR TITLE
8243547: Lanai - Netbeans IDE has BLACK background for the Toolbar and Statusbar

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/shaders.metal
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/shaders.metal
@@ -539,7 +539,7 @@ fragment half4 frag_txt_xorMode(
     ret.r = half( (unsigned char)(c.r * 255.0) ^ (unsigned char)(bgColor.r * 255.0)) / 255.0f;
     ret.g = half( (unsigned char)(c.g * 255.0) ^ (unsigned char)(bgColor.g * 255.0)) / 255.0f;
     ret.b = half( (unsigned char)(c.b * 255.0) ^ (unsigned char)(bgColor.b * 255.0)) / 255.0f;
-    ret.a = c.a;
+    ret.a = c.a + (1.0 - c.a) * bgColor.a;
 
     return ret;
 }

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
@@ -636,7 +636,7 @@ MTLBlitLoops_Blit(JNIEnv *env,
 #ifdef TRACE_BLIT
                     J2dTraceImpl(J2D_TRACE_VERBOSE, JNI_TRUE," [via pooled + blit]");
 #endif //TRACE_BLIT
-                    MTLBlitSwToTextureViaPooledTexture(mtlc, &srcInfo, dstOps, &rfi, true, hint, dx1, dy1, dx2, dy2);
+                    MTLBlitSwToTextureViaPooledTexture(mtlc, &srcInfo, dstOps, &rfi, false, hint, dx1, dy1, dx2, dy2);
                 }
             } else { // !useReplaceRegion
 #ifdef TRACE_BLIT

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.m
@@ -69,6 +69,7 @@
     self.leftInset = 0;
     self.framebufferOnly = NO;
     self.nextDrawableCount = 0;
+    self.opaque = FALSE;
     return self;
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPaints.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPaints.m
@@ -73,6 +73,10 @@ static void initTemplatePipelineDescriptors() {
     templateRenderPipelineDesc.sampleCount = 1;
     templateRenderPipelineDesc.vertexDescriptor = vertDesc;
     templateRenderPipelineDesc.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
+    templateRenderPipelineDesc.colorAttachments[0].sourceRGBBlendFactor = MTLBlendFactorOne;
+    templateRenderPipelineDesc.colorAttachments[0].sourceAlphaBlendFactor = MTLBlendFactorOne;
+    templateRenderPipelineDesc.colorAttachments[0].destinationRGBBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
+    templateRenderPipelineDesc.colorAttachments[0].destinationAlphaBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
     templateRenderPipelineDesc.label = @"template_render";
 
     templateTexturePipelineDesc = [templateRenderPipelineDesc copy];
@@ -85,10 +89,6 @@ static void initTemplatePipelineDescriptors() {
     templateTexturePipelineDesc.label = @"template_texture";
 
     templateAATexturePipelineDesc = [templateTexturePipelineDesc copy];
-    templateAATexturePipelineDesc.colorAttachments[0].sourceRGBBlendFactor = MTLBlendFactorOne;
-    templateAATexturePipelineDesc.colorAttachments[0].sourceAlphaBlendFactor = MTLBlendFactorOne;
-    templateAATexturePipelineDesc.colorAttachments[0].destinationRGBBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
-    templateAATexturePipelineDesc.colorAttachments[0].destinationAlphaBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
     templateAATexturePipelineDesc.label = @"template_aa_texture";
 
 }


### PR DESCRIPTION
Issue : https://bugs.openjdk.java.net/browse/JDK-8243547
Root Cause : Rendering with transparent color (RGBA 0000) was resulting in solid black color.
Fix : Made MTLLayer translucent to support transparent color rendering.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issues
 * [JDK-8243547](https://bugs.openjdk.java.net/browse/JDK-8243547): Lanai - Netbeans IDE has BLACK background for the Toolbar and Statusbar
 * [JDK-8240164](https://bugs.openjdk.java.net/browse/JDK-8240164): Test java/awt/Window/TranslucentShapedFrameTest/TranslucentShapedFrameTest.java fails for metal
 * [JDK-8240074](https://bugs.openjdk.java.net/browse/JDK-8240074): Test java/awt/Window/TranslucentJAppletTest/TranslucentJAppletTest.java fails for metal


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/84/head:pull/84`
`$ git checkout pull/84`
