### PR TITLE
8251023: Clipping of Image doesnt work when Alpha composite is enabled in J2DDemo

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
@@ -481,7 +481,7 @@ MTLBlitLoops_IsoBlit(JNIEnv *env,
 #endif //TRACE_ISOBLIT
 
     if (!texture && !xform
-        && [mtlc isBlendingDisabled:srcOps->isOpaque]
+        && srcOps->isOpaque
         && isIntegerAndUnscaled(sx1, sy1, sx2, sy2, dx1, dy1, dx2, dy2)
         && (dstOps->isOpaque || !srcOps->isOpaque)
     ) {
@@ -507,8 +507,8 @@ MTLBlitLoops_IsoBlit(JNIEnv *env,
     J2dTraceImpl(J2D_TRACE_VERBOSE, JNI_TRUE," [via sampling]");
 #endif //TRACE_ISOBLIT
     drawTex2Tex(mtlc, srcTex, dstTex,
-            [mtlc isBlendingDisabled:srcOps->isOpaque],
-            dstOps->isOpaque, hint, sx1, sy1, sx2, sy2, dx1, dy1, dx2, dy2);
+            srcOps->isOpaque, dstOps->isOpaque,
+            hint, sx1, sy1, sx2, sy2, dx1, dy1, dx2, dy2);
 }
 
 /**
@@ -622,9 +622,9 @@ MTLBlitLoops_Blit(JNIEnv *env,
 
             MTLRasterFormatInfo rfi = RasterFormatInfos[srctype];
             const jboolean useReplaceRegion = texture ||
-                    ([mtlc isBlendingDisabled:!rfi.hasAlpha]
-                    && !xform
-                    && isIntegerAndUnscaled(sx1, sy1, sx2, sy2, dx1, dy1, dx2, dy2));
+                    (!rfi.hasAlpha
+                     && !xform
+                     && isIntegerAndUnscaled(sx1, sy1, sx2, sy2, dx1, dy1, dx2, dy2));
 
             if (useReplaceRegion) {
                 if (dstOps->isOpaque || rfi.hasAlpha) {

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLComposite.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLComposite.h
@@ -33,7 +33,6 @@
 - (jint)getXorColor;
 - (jfloat)getExtraAlpha;
 
-- (jboolean)isBlendingDisabled:(jboolean) isSrcOpaque;
 - (NSString *)getDescription; // creates autorelease string
 @end
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLComposite.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLComposite.m
@@ -140,20 +140,6 @@
     return [NSString stringWithFormat:@"%s", result];
 }
 
-- (jboolean)isBlendingDisabled:(jboolean)isSrcOpaque {
-
-    // We need to check both extra alpha and isSrcOpaque for
-    // SRC mode for correct handling TRANSLUCENT images.
-    // See test/jdk/java/awt/image/DrawImage/IncorrectUnmanagedImageRotatedClip.java
-    // for example
-    if (_compositeRule == java_awt_AlphaComposite_SRC ||
-        _compositeRule == java_awt_AlphaComposite_SRC_OVER)
-    {
-        return FLT_GE(_extraAlpha, 1.0f) && isSrcOpaque;
-    }
-    return isSrcOpaque;
-}
-
 - (void)setAlphaComposite:(jint)rule {
     _compState = sun_java2d_SunGraphics2D_COMP_ALPHA;
     [self setRule:rule];

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.h
@@ -162,7 +162,6 @@
  * later in the MTLContext_SetColor() method.
  */
 - (void)setXorComposite:(jint)xorPixel;
-- (jboolean)isBlendingDisabled:(jboolean) isSrcOpaque;
 - (jboolean)useXORComposite;
 
 /**

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
@@ -285,10 +285,6 @@ extern void initSamplers(id<MTLDevice> device);
     [_composite setXORComposite:xp];
 }
 
-- (jboolean)isBlendingDisabled:(jboolean) isSrcOpaque {
-    return [_composite isBlendingDisabled:isSrcOpaque];
-}
-
 - (jboolean) useXORComposite {
     return ([_composite getCompositeState] == sun_java2d_SunGraphics2D_COMP_XOR);
 }


### PR DESCRIPTION
Remove extra alpha logic from isBlendingDisabled

Also, this fix helps with background problem in this issue https://bugs.openjdk.java.net/browse/JDK-8244727
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8251023](https://bugs.openjdk.java.net/browse/JDK-8251023): Clipping of Image doesnt work when Alpha composite is enabled in J2DDemo


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/97/head:pull/97`
`$ git checkout pull/97`
