### PR TITLE
8252499: UI text of application with metal pipeline is lost when another application is launched with OpenGL pipeline

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderQueue.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderQueue.m
@@ -871,6 +871,7 @@ Java_sun_java2d_metal_MTLRenderQueue_flushBuffer
                     BMTLSDOps *mtlsdo = (BMTLSDOps *)jlong_to_ptr(pData);
                     if (mtlsdo != NULL) {
                         CONTINUE_IF_NULL(mtlc);
+                        MTLTR_FreeGlyphCaches();
                         MTLSD_Delete(env, mtlsdo);
                     }
                     break;

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLTextRenderer.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLTextRenderer.h
@@ -47,6 +47,7 @@
 void MTLTR_EnableGlyphVertexCache(MTLContext *mtlc, BMTLSDOps *dstOps);
 void MTLTR_DisableGlyphVertexCache(MTLContext *mtlc);
 id<MTLTexture> MTLTR_GetGlyphCacheTexture();
+void MTLTR_FreeGlyphCaches();
 
 void MTLTR_DrawGlyphList(JNIEnv *env, MTLContext *mtlc, BMTLSDOps *dstOps,
                          jint totalGlyphs, jboolean usePositions,

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLTextRenderer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLTextRenderer.m
@@ -443,6 +443,22 @@ MTLTR_DisableGlyphVertexCache(MTLContext *mtlc)
     MTLVertexCache_FreeVertexCache();
 }
 
+void MTLTR_FreeGlyphCaches() {
+    J2dTraceLn(J2D_TRACE_INFO, "MTLTR_FreeGlyphCaches : freeing glyph caches.");
+
+    if (glyphCacheAA != NULL) {
+        [glyphCacheAA->texture release];
+        MTLGlyphCache_Free(glyphCacheAA);
+        glyphCacheAA = NULL;
+    }
+
+    if (glyphCacheLCD != NULL) {
+        [glyphCacheLCD->texture release];
+        MTLGlyphCache_Free(glyphCacheLCD);
+        glyphCacheLCD = NULL;
+    }
+}
+
 static jboolean
 MTLTR_DrawGrayscaleGlyphViaCache(MTLContext *mtlc,
                                  GlyphInfo *ginfo, jint x, jint y, BMTLSDOps *dstOps)


### PR DESCRIPTION
Issue : https://bugs.openjdk.java.net/browse/JDK-8252499

Root cause : Text glyph cache created on one device (graphics card) is continued to be used even after graphics card switch.
 
Fix : We already delete SurfaceData on graphics card switch. I have added code to free the text glyph cache at the same location. Note - The text glyph cache gets recreated on new device with exiting code flow - hence there is no need to add new code to handle it.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8252499](https://bugs.openjdk.java.net/browse/JDK-8252499): UI text of application with metal pipeline is lost when another application is launched with OpenGL pipeline


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/103/head:pull/103`
`$ git checkout pull/103`
