### PR TITLE
8253840: Lanai - MTLClip.beginShapeClip method uses a larger temporary buffer than needed

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLClip.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLClip.m
@@ -151,11 +151,11 @@ static id<MTLDepthStencilState> getStencilState(id<MTLDevice> device) {
 
         NSUInteger width = (NSUInteger)dstOps->width;
         NSUInteger height = (NSUInteger)dstOps->height;
-        NSUInteger size = width*height;
-        id <MTLBuffer> buff = [mtlc.device newBufferWithLength:size*4 options:MTLResourceStorageModePrivate];
+        NSUInteger size = width * height;
+        id <MTLBuffer> buff = [mtlc.device newBufferWithLength:size options:MTLResourceStorageModePrivate];
         id<MTLCommandBuffer> commandBuf = [mtlc createCommandBuffer];
         id<MTLBlitCommandEncoder> blitEncoder = [commandBuf blitCommandEncoder];
-        [blitEncoder fillBuffer:buff range:NSMakeRange(0, size*4) value:0];
+        [blitEncoder fillBuffer:buff range:NSMakeRange(0, size) value:0];
 
         MTLOrigin origin = MTLOriginMake(0, 0, 0);
         MTLSize sourceSize = MTLSizeMake(width, height, 1);
@@ -199,8 +199,7 @@ static id<MTLDepthStencilState> getStencilState(id<MTLDevice> device) {
         if (dstOps->width > 0 && dstOps->height > 0) {
             NSUInteger width = (NSUInteger)dstOps->width;
             NSUInteger height = (NSUInteger)dstOps->height;
-            NSUInteger size = width*height;
-            NSUInteger sizeX4 = size*4;
+            NSUInteger size = width * height;
 
             id<MTLCommandBuffer> cb = [mtlc createCommandBuffer];
             id<MTLBlitCommandEncoder> blitEncoder = [cb blitCommandEncoder];


### PR DESCRIPTION
Issue : A temporary buffer which is 4 times larger is allocated and filled with 0's - but only 1/4th of it is used while copying.
Fix : Corrected the size of temporary buffer. Done spacing correction at two places and also removed an unused variable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8253840](https://bugs.openjdk.java.net/browse/JDK-8253840): Lanai - MTLClip.beginShapeClip method uses a larger temporary buffer than needed


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/110/head:pull/110`
`$ git checkout pull/110`
