### PR TITLE
8242924: Selection is not correct in Paint.TextureAnim

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPaints.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPaints.m
@@ -77,6 +77,8 @@ static void initTemplatePipelineDescriptors() {
     templateRenderPipelineDesc.sampleCount = 1;
     templateRenderPipelineDesc.vertexDescriptor = vertDesc;
     templateRenderPipelineDesc.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
+    templateRenderPipelineDesc.colorAttachments[0].rgbBlendOperation =   MTLBlendOperationAdd;
+    templateRenderPipelineDesc.colorAttachments[0].alphaBlendOperation = MTLBlendOperationAdd;
     templateRenderPipelineDesc.colorAttachments[0].sourceRGBBlendFactor = MTLBlendFactorOne;
     templateRenderPipelineDesc.colorAttachments[0].sourceAlphaBlendFactor = MTLBlendFactorOne;
     templateRenderPipelineDesc.colorAttachments[0].destinationRGBBlendFactor = MTLBlendFactorOneMinusSourceAlpha;

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPipelineStatesStorage.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPipelineStatesStorage.m
@@ -162,8 +162,8 @@ static void setBlendingFactors(
                 pipelineDesc.sampleCount = MTLAASampleCount;
                 pipelineDesc.colorAttachments[0].rgbBlendOperation =   MTLBlendOperationAdd;
                 pipelineDesc.colorAttachments[0].alphaBlendOperation = MTLBlendOperationAdd;
-                pipelineDesc.colorAttachments[0].sourceRGBBlendFactor = MTLBlendFactorSourceAlpha;
-                pipelineDesc.colorAttachments[0].sourceAlphaBlendFactor = MTLBlendFactorSourceAlpha;
+                pipelineDesc.colorAttachments[0].sourceRGBBlendFactor = MTLBlendFactorOne;
+                pipelineDesc.colorAttachments[0].sourceAlphaBlendFactor = MTLBlendFactorOne;
                 pipelineDesc.colorAttachments[0].destinationRGBBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
                 pipelineDesc.colorAttachments[0].destinationAlphaBlendFactor = MTLBlendFactorOneMinusSourceAlpha;
                 pipelineDesc.colorAttachments[0].blendingEnabled = YES;


### PR DESCRIPTION
Corrected Source blend factors of AA rendering.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ⏳ (3/3 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issues
 * [JDK-8242924](https://bugs.openjdk.java.net/browse/JDK-8242924): Selection is not correct in Paint.TextureAnim
 * [JDK-8253994](https://bugs.openjdk.java.net/browse/JDK-8253994): J2DDemo: Buttcap, SquareCap color is different in AlphaComposite mode


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/114/head:pull/114`
`$ git checkout pull/114`
