### PR TITLE
8244845: Lanai : J2DDemo - Clipping - Two parallel lines do not appear with AA Rendering

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderQueue.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderQueue.m
@@ -511,7 +511,7 @@ Java_sun_java2d_metal_MTLRenderQueue_flushBuffer
                     jfloat lwr21 = NEXT_FLOAT(b);
                     jfloat lwr12 = NEXT_FLOAT(b);
 
-                    MTLRenderer_DrawParallelogram(mtlc, dstOps,
+                    MTLRenderer_DrawParallelogram(mtlc, dstOps, JNI_FALSE,
                                                   x11, y11,
                                                   dx21, dy21,
                                                   dx12, dy12,
@@ -530,7 +530,7 @@ Java_sun_java2d_metal_MTLRenderQueue_flushBuffer
                     jfloat lwr21 = NEXT_FLOAT(b);
                     jfloat lwr12 = NEXT_FLOAT(b);
 
-                    MTLRenderer_DrawAAParallelogram(mtlc, dstOps,
+                    MTLRenderer_DrawParallelogram(mtlc, dstOps, JNI_TRUE,
                                                     x11, y11,
                                                     dx21, dy21,
                                                     dx12, dy12,
@@ -588,7 +588,7 @@ Java_sun_java2d_metal_MTLRenderQueue_flushBuffer
                     jfloat dy21 = NEXT_FLOAT(b);
                     jfloat dx12 = NEXT_FLOAT(b);
                     jfloat dy12 = NEXT_FLOAT(b);
-                    MTLRenderer_FillParallelogram(mtlc, dstOps,
+                    MTLRenderer_FillParallelogram(mtlc, dstOps, JNI_FALSE,
                                                   x11, y11,
                                                   dx21, dy21,
                                                   dx12, dy12);
@@ -603,7 +603,7 @@ Java_sun_java2d_metal_MTLRenderQueue_flushBuffer
                     jfloat dy21 = NEXT_FLOAT(b);
                     jfloat dx12 = NEXT_FLOAT(b);
                     jfloat dy12 = NEXT_FLOAT(b);
-                    MTLRenderer_FillAAParallelogram(mtlc, dstOps,
+                    MTLRenderer_FillParallelogram(mtlc, dstOps, JNI_TRUE,
                                                     x11, y11,
                                                     dx21, dy21,
                                                     dx12, dy12);

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderer.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderer.h
@@ -50,31 +50,19 @@ void MTLRenderer_DrawPoly(MTLContext *mtlc, BMTLSDOps * dstOps,
                           jint *xPoints, jint *yPoints);
 void MTLRenderer_DrawScanlines(MTLContext *mtlc, BMTLSDOps * dstOps,
                                jint count, jint *scanlines);
-void MTLRenderer_DrawParallelogram(MTLContext *mtlc, BMTLSDOps * dstOps,
+void MTLRenderer_DrawParallelogram(MTLContext *mtlc, BMTLSDOps * dstOps, jboolean isAA,
                                    jfloat fx11, jfloat fy11,
                                    jfloat dx21, jfloat dy21,
                                    jfloat dx12, jfloat dy12,
                                    jfloat lw21, jfloat lw12);
-void MTLRenderer_DrawAAParallelogram(MTLContext *mtlc, BMTLSDOps *dstOps,
-                                     jfloat fx11, jfloat fy11,
-                                     jfloat dx21, jfloat dy21,
-                                     jfloat dx12, jfloat dy12,
-                                     jfloat lw21, jfloat lw12);
 
 void MTLRenderer_FillRect(MTLContext *mtlc, BMTLSDOps * dstOps,
                           jint x, jint y, jint w, jint h);
 void MTLRenderer_FillSpans(MTLContext *mtlc, BMTLSDOps * dstOps,
                            jint count, jint *spans);
-void MTLRenderer_FillParallelogram(MTLContext *mtlc, BMTLSDOps * dstOps,
+void MTLRenderer_FillParallelogram(MTLContext *mtlc, BMTLSDOps * dstOps, jboolean isAA,
                                    jfloat fx11, jfloat fy11,
                                    jfloat dx21, jfloat dy21,
                                    jfloat dx12, jfloat dy12);
-void MTLRenderer_FillAAParallelogram(MTLContext *mtlc, BMTLSDOps *dstOps,
-                                     jfloat fx11, jfloat fy11,
-                                     jfloat dx21, jfloat dy21,
-                                     jfloat dx12, jfloat dy12);
-
-void MTLRenderer_EnableAAParallelogramProgram();
-void MTLRenderer_DisableAAParallelogramProgram();
 
 #endif /* MTLRenderer_h_Included */

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderer.m
@@ -424,7 +424,7 @@ void MTLRenderer_FillSpans(MTLContext *mtlc, BMTLSDOps * dstOps, jint spanCount,
 }
 
 void
-MTLRenderer_FillParallelogram(MTLContext *mtlc, BMTLSDOps * dstOps,
+MTLRenderer_FillParallelogram(MTLContext *mtlc, BMTLSDOps * dstOps, jboolean isAA,
                               jfloat fx11, jfloat fy11,
                               jfloat dx21, jfloat dy21,
                               jfloat dx12, jfloat dy12)
@@ -436,11 +436,12 @@ MTLRenderer_FillParallelogram(MTLContext *mtlc, BMTLSDOps * dstOps,
     }
 
     id<MTLTexture> dest = dstOps->pTexture;
-    J2dTraceLn7(J2D_TRACE_INFO,
-                "MTLRenderer_FillParallelogram "
+    J2dTraceLn8(J2D_TRACE_INFO,
+                "MTLRenderer_FillParallelogram (isAA = %d)"
                 "(x=%6.2f y=%6.2f "
                 "dx1=%6.2f dy1=%6.2f "
                 "dx2=%6.2f dy2=%6.2f dst tex=%p)",
+                isAA,
                 fx11, fy11,
                 dx21, dy21,
                 dx12, dy12, dest);
@@ -453,16 +454,24 @@ MTLRenderer_FillParallelogram(MTLContext *mtlc, BMTLSDOps * dstOps,
         }};
 
     // Encode render command.
-    id<MTLRenderCommandEncoder> mtlEncoder = [mtlc.encoderManager getRenderEncoder:dstOps];
-    if (mtlEncoder == nil)
+    id<MTLRenderCommandEncoder> mtlEncoder = nil;
+    if (isAA == JNI_TRUE) {
+        mtlEncoder = [mtlc.encoderManager getAARenderEncoder:dstOps];
+    } else {
+        mtlEncoder = [mtlc.encoderManager getRenderEncoder:dstOps];
+    }
+
+    if (mtlEncoder == nil) {
+        J2dRlsTraceLn(J2D_TRACE_ERROR, "MTLRenderer_FillParallelogram: error creating MTLRenderCommandEncoder.");
         return;
+    }
 
     [mtlEncoder setVertexBytes:verts length:sizeof(verts) atIndex:MeshVertexBuffer];
     [mtlEncoder drawPrimitives:MTLPrimitiveTypeTriangleStrip vertexStart:0 vertexCount: QUAD_VERTEX_COUNT];
 }
 
 void
-MTLRenderer_DrawParallelogram(MTLContext *mtlc, BMTLSDOps * dstOps,
+MTLRenderer_DrawParallelogram(MTLContext *mtlc, BMTLSDOps * dstOps, jboolean isAA,
                               jfloat fx11, jfloat fy11,
                               jfloat dx21, jfloat dy21,
                               jfloat dx12, jfloat dy12,
@@ -478,8 +487,8 @@ MTLRenderer_DrawParallelogram(MTLContext *mtlc, BMTLSDOps * dstOps,
     jfloat ox11 = fx11 - (ldx21 + ldx12) / 2.0f;
     jfloat oy11 = fy11 - (ldy21 + ldy12) / 2.0f;
 
+    J2dTraceLn1(J2D_TRACE_INFO, "MTLRenderer_DrawParallelogram (isAA = %d)", isAA);
     J2dTraceLn8(J2D_TRACE_INFO,
-                "MTLRenderer_DrawParallelogram "
                 "(x=%6.2f y=%6.2f "
                 "dx1=%6.2f dy1=%6.2f lwr1=%6.2f "
                 "dx2=%6.2f dy2=%6.2f lwr2=%6.2f)",
@@ -574,9 +583,17 @@ MTLRenderer_DrawParallelogram(MTLContext *mtlc, BMTLSDOps * dstOps,
         fillVertex(vertexList + (i++), fx11, fy11);
 
         // Encode render command.
-        id<MTLRenderCommandEncoder> mtlEncoder = [mtlc.encoderManager getRenderEncoder:dstOps];
-        if (mtlEncoder == nil)
+        id<MTLRenderCommandEncoder> mtlEncoder = nil;
+        if (isAA == JNI_TRUE) {
+            mtlEncoder = [mtlc.encoderManager getAARenderEncoder:dstOps];
+        } else {
+            mtlEncoder = [mtlc.encoderManager getRenderEncoder:dstOps];
+        }
+
+        if (mtlEncoder == nil) {
+            J2dRlsTraceLn(J2D_TRACE_ERROR, "MTLRenderer_DrawParallelogram: error creating MTLRenderCommandEncoder.");
             return;
+        }
 
         [mtlEncoder setVertexBytes:vertexList length:sizeof(vertexList) atIndex:MeshVertexBuffer];
         [mtlEncoder drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:TOTAL_VERTICES];
@@ -589,237 +606,8 @@ MTLRenderer_DrawParallelogram(MTLContext *mtlc, BMTLSDOps * dstOps,
         dy21 += ldy21;
         dx12 += ldx12;
         dy12 += ldy12;
-        MTLRenderer_FillParallelogram(mtlc, dstOps, ox11, oy11, dx21, dy21, dx12, dy12);
+        MTLRenderer_FillParallelogram(mtlc, dstOps, isAA, ox11, oy11, dx21, dy21, dx12, dy12);
     }
-}
-
-
-static GLhandleARB aaPgramProgram = 0;
-
-/*
- * This shader fills the space between an outer and inner parallelogram.
- * It can be used to draw an outline by specifying both inner and outer
- * values.  It fills pixels by estimating what portion falls inside the
- * outer shape, and subtracting an estimate of what portion falls inside
- * the inner shape.  Specifying both inner and outer values produces a
- * standard "wide outline".  Specifying an inner shape that falls far
- * outside the outer shape allows the same shader to fill the outer
- * shape entirely since pixels that fall within the outer shape are never
- * inside the inner shape and so they are filled based solely on their
- * coverage of the outer shape.
- *
- * The setup code renders this shader over the bounds of the outer
- * shape (or the only shape in the case of a fill operation) and
- * sets the texture 0 coordinates so that 0,0=>0,1=>1,1=>1,0 in those
- * texture coordinates map to the four corners of the parallelogram.
- * Similarly the texture 1 coordinates map the inner shape to the
- * unit square as well, but in a different coordinate system.
- *
- * When viewed in the texture coordinate systems the parallelograms
- * we are filling are unit squares, but the pixels have then become
- * tiny parallelograms themselves.  Both of the texture coordinate
- * systems are affine transforms so the rate of change in X and Y
- * of the texture coordinates are essentially constants and happen
- * to correspond to the size and direction of the slanted sides of
- * the distorted pixels relative to the "square mapped" boundary
- * of the parallelograms.
- *
- * The shader uses the dFdx() and dFdy() functions to measure the "rate
- * of change" of these texture coordinates and thus gets an accurate
- * measure of the size and shape of a pixel relative to the two
- * parallelograms.  It then uses the bounds of the size and shape
- * of a pixel to intersect with the unit square to estimate the
- * coverage of the pixel.  Unfortunately, without a lot more work
- * to calculate the exact area of intersection between a unit
- * square (the original parallelogram) and a parallelogram (the
- * distorted pixel), this shader only approximates the pixel
- * coverage, but emperically the estimate is very useful and
- * produces visually pleasing results, if not theoretically accurate.
- */
-static const char *aaPgramShaderSource =
-    "void main() {"
-    // Calculate the vectors for the "legs" of the pixel parallelogram
-    // for the outer parallelogram.
-    "    vec2 oleg1 = dFdx(gl_TexCoord[0].st);"
-    "    vec2 oleg2 = dFdy(gl_TexCoord[0].st);"
-    // Calculate the bounds of the distorted pixel parallelogram.
-    "    vec2 corner = gl_TexCoord[0].st - (oleg1+oleg2)/2.0;"
-    "    vec2 omin = min(corner, corner+oleg1);"
-    "    omin = min(omin, corner+oleg2);"
-    "    omin = min(omin, corner+oleg1+oleg2);"
-    "    vec2 omax = max(corner, corner+oleg1);"
-    "    omax = max(omax, corner+oleg2);"
-    "    omax = max(omax, corner+oleg1+oleg2);"
-    // Calculate the vectors for the "legs" of the pixel parallelogram
-    // for the inner parallelogram.
-    "    vec2 ileg1 = dFdx(gl_TexCoord[1].st);"
-    "    vec2 ileg2 = dFdy(gl_TexCoord[1].st);"
-    // Calculate the bounds of the distorted pixel parallelogram.
-    "    corner = gl_TexCoord[1].st - (ileg1+ileg2)/2.0;"
-    "    vec2 imin = min(corner, corner+ileg1);"
-    "    imin = min(imin, corner+ileg2);"
-    "    imin = min(imin, corner+ileg1+ileg2);"
-    "    vec2 imax = max(corner, corner+ileg1);"
-    "    imax = max(imax, corner+ileg2);"
-    "    imax = max(imax, corner+ileg1+ileg2);"
-    // Clamp the bounds of the parallelograms to the unit square to
-    // estimate the intersection of the pixel parallelogram with
-    // the unit square.  The ratio of the 2 rectangle areas is a
-    // reasonable estimate of the proportion of coverage.
-    "    vec2 o1 = clamp(omin, 0.0, 1.0);"
-    "    vec2 o2 = clamp(omax, 0.0, 1.0);"
-    "    float oint = (o2.y-o1.y)*(o2.x-o1.x);"
-    "    float oarea = (omax.y-omin.y)*(omax.x-omin.x);"
-    "    vec2 i1 = clamp(imin, 0.0, 1.0);"
-    "    vec2 i2 = clamp(imax, 0.0, 1.0);"
-    "    float iint = (i2.y-i1.y)*(i2.x-i1.x);"
-    "    float iarea = (imax.y-imin.y)*(imax.x-imin.x);"
-    // Proportion of pixel in outer shape minus the proportion
-    // of pixel in the inner shape == the coverage of the pixel
-    // in the area between the two.
-    "    float coverage = oint/oarea - iint / iarea;"
-    "    gl_FragColor = gl_Color * coverage;"
-    "}";
-
-#define ADJUST_PGRAM(V1, DV, V2) \
-    do { \
-        if ((DV) >= 0) { \
-            (V2) += (DV); \
-        } else { \
-            (V1) += (DV); \
-        } \
-    } while (0)
-
-// Invert the following transform:
-// DeltaT(0, 0) == (0,       0)
-// DeltaT(1, 0) == (DX1,     DY1)
-// DeltaT(0, 1) == (DX2,     DY2)
-// DeltaT(1, 1) == (DX1+DX2, DY1+DY2)
-// TM00 = DX1,   TM01 = DX2,   (TM02 = X11)
-// TM10 = DY1,   TM11 = DY2,   (TM12 = Y11)
-// Determinant = TM00*TM11 - TM01*TM10
-//             =  DX1*DY2  -  DX2*DY1
-// Inverse is:
-// IM00 =  TM11/det,   IM01 = -TM01/det
-// IM10 = -TM10/det,   IM11 =  TM00/det
-// IM02 = (TM01 * TM12 - TM11 * TM02) / det,
-// IM12 = (TM10 * TM02 - TM00 * TM12) / det,
-
-#define DECLARE_MATRIX(MAT) \
-    jfloat MAT ## 00, MAT ## 01, MAT ## 02, MAT ## 10, MAT ## 11, MAT ## 12
-
-#define GET_INVERTED_MATRIX(MAT, X11, Y11, DX1, DY1, DX2, DY2, RET_CODE) \
-    do { \
-        jfloat det = DX1*DY2 - DX2*DY1; \
-        if (det == 0) { \
-            RET_CODE; \
-        } \
-        MAT ## 00 = DY2/det; \
-        MAT ## 01 = -DX2/det; \
-        MAT ## 10 = -DY1/det; \
-        MAT ## 11 = DX1/det; \
-        MAT ## 02 = (DX2 * Y11 - DY2 * X11) / det; \
-        MAT ## 12 = (DY1 * X11 - DX1 * Y11) / det; \
-    } while (0)
-
-#define TRANSFORM(MAT, TX, TY, X, Y) \
-    do { \
-        TX = (X) * MAT ## 00 + (Y) * MAT ## 01 + MAT ## 02; \
-        TY = (X) * MAT ## 10 + (Y) * MAT ## 11 + MAT ## 12; \
-    } while (0)
-
-void
-MTLRenderer_FillAAParallelogram(MTLContext *mtlc, BMTLSDOps *dstOps,
-                                jfloat fx11, jfloat fy11,
-                                jfloat dx21, jfloat dy21,
-                                jfloat dx12, jfloat dy12)
-{
-    if (mtlc == NULL || dstOps == NULL || dstOps->pTexture == NULL) {
-        J2dRlsTraceLn(J2D_TRACE_ERROR, "MTLRenderer_FillParallelogram: current dest is null");
-        return;
-    }
-
-    J2dTraceLn7(J2D_TRACE_INFO,
-                "MTLRenderer_FillAAParallelogram "
-                "(x=%6.2f y=%6.2f "
-                "dx1=%6.2f dy1=%6.2f "
-                "dx2=%6.2f dy2=%6.2f dst tex=%p)",
-                fx11, fy11,
-                dx21, dy21,
-                dx12, dy12, dstOps->pTexture);
-
-    struct Vertex verts[QUAD_VERTEX_COUNT] = {
-            { {fx11, fy11}},
-            { {fx11+dx21, fy11+dy21}},
-            { {fx11+dx12, fy11+dy12}},
-            { {fx11 + dx21 + dx12, fy11+ dy21 + dy12}
-            }};
-
-    id<MTLTexture> dstTxt = dstOps->pTexture;
-
-    // Encode render command.
-    id<MTLRenderCommandEncoder> mtlEncoder =
-        [mtlc.encoderManager getAARenderEncoder:dstOps];
-
-    if (mtlEncoder == nil) {
-        return;
-    }
-
-    [mtlEncoder setVertexBytes:verts length:sizeof(verts) atIndex:MeshVertexBuffer];
-    [mtlEncoder drawPrimitives:MTLPrimitiveTypeTriangleStrip vertexStart:0 vertexCount: QUAD_VERTEX_COUNT];
-}
-
-void
-MTLRenderer_FillAAParallelogramInnerOuter(MTLContext *mtlc, MTLSDOps *dstOps,
-                                          jfloat ox11, jfloat oy11,
-                                          jfloat ox21, jfloat oy21,
-                                          jfloat ox12, jfloat oy12,
-                                          jfloat ix11, jfloat iy11,
-                                          jfloat ix21, jfloat iy21,
-                                          jfloat ix12, jfloat iy12)
-{
-    //TODO
-    J2dTraceLn(J2D_TRACE_ERROR, "MTLRenderer_FillAAParallelogramInnerOuter -- :TODO");
-}
-
-void
-MTLRenderer_DrawAAParallelogram(MTLContext *mtlc, BMTLSDOps *dstOps,
-                                jfloat fx11, jfloat fy11,
-                                jfloat dx21, jfloat dy21,
-                                jfloat dx12, jfloat dy12,
-                                jfloat lwr21, jfloat lwr12)
-{
-    //TODO
-    // dx,dy for line width in the "21" and "12" directions.
-    jfloat ldx21, ldy21, ldx12, ldy12;
-    // parameters for "outer" parallelogram
-    jfloat ofx11, ofy11, odx21, ody21, odx12, ody12;
-    // parameters for "inner" parallelogram
-    jfloat ifx11, ify11, idx21, idy21, idx12, idy12;
-
-    J2dTraceLn8(J2D_TRACE_ERROR,
-                "MTLRenderer_DrawAAParallelogram -- :TODO"
-                "(x=%6.2f y=%6.2f "
-                "dx1=%6.2f dy1=%6.2f lwr1=%6.2f "
-                "dx2=%6.2f dy2=%6.2f lwr2=%6.2f)",
-                fx11, fy11,
-                dx21, dy21, lwr21,
-                dx12, dy12, lwr12);
-
-}
-
-void
-MTLRenderer_EnableAAParallelogramProgram()
-{
-    //TODO
-    J2dTraceLn(J2D_TRACE_INFO, "MTLRenderer_EnableAAParallelogramProgram -- :TODO");
-}
-
-void
-MTLRenderer_DisableAAParallelogramProgram()
-{
-    //TODO
-    J2dTraceLn(J2D_TRACE_INFO, "MTLRenderer_DisableAAParallelogramProgram -- :TODO");
 }
 
 #endif /* !HEADLESS */


### PR DESCRIPTION
Implemented DrawParalleogram method for AA rendering. Also, made DrawParalleogram and FillParalleogram methods common for AA and non-AA rendering as all calculations are common, but only render encoders differ.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ⏳ (1/3 running) | ⏳ (2/2 running) | ✔️ (2/2 passed) |
| Test (tier1) |    |     |  ⏳ (5/9 running) |

### Issue
 * [JDK-8244845](https://bugs.openjdk.java.net/browse/JDK-8244845): Lanai : J2DDemo - Clipping - Two parallel lines do not appear with AA Rendering


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/115/head:pull/115`
`$ git checkout pull/115`
