### PR TITLE
8244718: J2DDemo - AlphaComposite tab - output colors are different with AA & non-AA

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/shaders.metal
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/shaders.metal
@@ -179,7 +179,7 @@ fragment half4 frag_txt(
 
     return half4(pixelColor.r,
                  pixelColor.g,
-                 pixelColor.b, srcA*uniforms.extraAlpha);
+                 pixelColor.b, srcA)*uniforms.extraAlpha;
 }
 
 fragment half4 frag_txt_tp(TxtShaderInOut vert [[stage_in]],
@@ -327,7 +327,7 @@ fragment half4 frag_txt_op_rescale(
     // TODO: check uniforms.isNonPremult and pre-multiply if necessary
     return half4(srcColor.r*uniforms.normScaleFactors.r + uniforms.normOffsets.r,
                  srcColor.g*uniforms.normScaleFactors.g + uniforms.normOffsets.g,
-                 srcColor.b*uniforms.normScaleFactors.b + uniforms.normOffsets.b, srcA*uniforms.extraAlpha);
+                 srcColor.b*uniforms.normScaleFactors.b + uniforms.normOffsets.b, srcA)*uniforms.extraAlpha;
 
     // NOTE: GL-shader multiplies result with glColor (in order to apply extra alpha), probably it's better to do the
     // same here.
@@ -368,7 +368,7 @@ fragment half4 frag_txt_op_convolve(
         sum.a += kern.z * pixCol.a;
     }
     const float srcA = uniforms.isSrcOpaque ? 1 : sum.a;
-    return half4(sum.r, sum.g, sum.b, srcA*uniforms.extraAlpha);
+    return half4(sum.r, sum.g, sum.b, srcA)*uniforms.extraAlpha;
 
     // NOTE: GL-shader multiplies result with glColor (in order to apply extra alpha), probably it's better to do the
     // same here.
@@ -411,7 +411,7 @@ fragment half4 frag_txt_op_lookup(
     const float a = uniforms.isUseSrcAlpha ? srcA : lookupTex.sample(textureSampler, float2(srcIndex.a, 0.875)).a;
 
     // TODO: check uniforms.isNonPremult and pre-multiply if necessary
-    return half4(lookupR.a, lookupG.a, lookupB.a, a*uniforms.extraAlpha);
+    return half4(lookupR.a, lookupG.a, lookupB.a, a)*uniforms.extraAlpha;
 
     // NOTE: GL-shader multiplies result with glColor (in order to apply extra alpha), probably it's better to do the
     // same here.
@@ -666,7 +666,7 @@ fragment half4 frag_txt_xorMode(
     } else {
         c = float4(pixelColor.r,
                  pixelColor.g,
-                 pixelColor.b, srcA*uniforms.extraAlpha);
+                 pixelColor.b, srcA)*uniforms.extraAlpha;
     }
 
     half4 ret;


### PR DESCRIPTION
A straight forward approach to handle blending modes.

Fixes those bugs
- https://bugs.openjdk.java.net/browse/JDK-8244718
- https://bugs.openjdk.java.net/browse/JDK-8251032
- https://bugs.openjdk.java.net/browse/JDK-8253992

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build | ⏳ (2/5 running) | ⏳ (2/2 running) | ❌ (1/2 failed) |

**Failed test task**
- [macOS x64 (build release)](https://github.com/dekonoplyov/lanai/runs/1283109520)

### Issue
 * [JDK-8244718](https://bugs.openjdk.java.net/browse/JDK-8244718): J2DDemo - AlphaComposite tab - output colors are different with AA & non-AA


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/120/head:pull/120`
`$ git checkout pull/120`
