### PR TITLE
8238533: [Lanai] Support texture paint where source is transparent

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/shaders.metal
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/shaders.metal
@@ -599,17 +599,13 @@ vertex TxtShaderInOut vert_tp(VertexInput in [[stage_in]],
 
 fragment half4 frag_tp(
         TxtShaderInOut vert [[stage_in]],
-        texture2d<float, access::sample> renderTexture [[texture(0)]])
+        texture2d<float, access::sample> renderTexture [[texture(0)]],
+        constant TxtFrameUniforms& uniforms [[buffer(1)]],
+        sampler textureSampler [[sampler(0)]])
 {
-    constexpr sampler textureSampler (address::repeat,
-                                      mag_filter::nearest,
-                                      min_filter::nearest);
-
     float4 pixelColor = renderTexture.sample(textureSampler, vert.texCoords);
-    return half4(pixelColor.r, pixelColor.g, pixelColor.b, 1.0);
-
-    // This implementation defaults alpha to 1.0 as if source is opaque
-    //TODO : implement alpha component value if source is transparent
+    const float srcA = uniforms.isSrcOpaque ? 1 : pixelColor.a;
+    return half4(pixelColor.r, pixelColor.g, pixelColor.b, srcA) * uniforms.extraAlpha;
 }
 
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/shaders.metal
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/shaders.metal
@@ -256,14 +256,16 @@ fragment half4 frag_txt(
 fragment half4 frag_txt_tp(TxtShaderInOut vert [[stage_in]],
                        texture2d<float, access::sample> renderTexture [[texture(0)]],
                        texture2d<float, access::sample> paintTexture [[texture(1)]],
+                       constant TxtFrameUniforms& uniforms [[buffer(1)]],
                        sampler textureSampler [[sampler(0)]]
 ) {
     float4 renderColor = renderTexture.sample(textureSampler, vert.texCoords);
     float4 paintColor = paintTexture.sample(textureSampler, vert.tpCoords);
+    const float srcA = uniforms.isSrcOpaque ? 1 : paintColor.a;
     return half4(paintColor.r*renderColor.a,
                  paintColor.g*renderColor.a,
                  paintColor.b*renderColor.a,
-                 renderColor.a);
+                 srcA*renderColor.a) * uniforms.extraAlpha;
 }
 
 fragment half4 frag_txt_grad(GradShaderInOut in [[stage_in]],

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
@@ -435,6 +435,7 @@ extern void initSamplers(id<MTLDevice> device);
 
     self.paint = [[[MTLTexturePaint alloc] initWithUseMask:useMask
                                                 textureID:srcOps->pTexture
+                                                  isOpaque:srcOps->isOpaque
                                                    filter:filter
                                                       xp0:xp0
                                                       xp1:xp1

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
@@ -442,7 +442,7 @@ extern void initSamplers(id<MTLDevice> device);
                                                       xp3:xp3
                                                       yp0:yp0
                                                       yp1:yp1
-                                                      yp3:yp3] autorelease] ;
+                                                      yp3:yp3] autorelease];
 }
 
 - (id<MTLCommandBuffer>)createCommandBuffer {

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPaints.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPaints.h
@@ -133,6 +133,7 @@
 
 - (id)initWithUseMask:(jboolean)useMask
               textureID:(id <MTLTexture>)textureID
+               isOpaque:(jboolean)isOpaque
                  filter:(jboolean)filter
                     xp0:(jdouble)xp0
                     xp1:(jdouble)xp1

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPaints.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPaints.m
@@ -657,10 +657,12 @@ jint _color;
 @implementation MTLTexturePaint {
     struct AnchorData _anchor;
     id <MTLTexture> _paintTexture;
+    jboolean _isOpaque;
 }
 
 - (id)initWithUseMask:(jboolean)useMask
               textureID:(id)textureId
+               isOpaque:(jboolean)isOpaque
                  filter:(jboolean)filter
                     xp0:(jdouble)xp0
                     xp1:(jdouble)xp1
@@ -680,6 +682,7 @@ jint _color;
         _anchor.yParams[0] = yp0;
         _anchor.yParams[1] = yp1;
         _anchor.yParams[2] = yp3;
+        _isOpaque = isOpaque;
     }
     return self;
 
@@ -701,7 +704,7 @@ jint _color;
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"radial_gradient"];
+    return [NSString stringWithFormat:@"texture_paint"];
 }
 
 - (void)setPipelineState:(id)encoder
@@ -727,6 +730,11 @@ jint _color;
     } else {
         rpDesc = [[templateRenderPipelineDesc copy] autorelease];
         [encoder setFragmentTexture:_paintTexture atIndex:0];
+        const SurfaceRasterFlags srcFlags = {_isOpaque, renderOptions->srcFlags.isPremultiplied};
+        setTxtUniforms(encoder, 0, 0,
+                       renderOptions->interpolation, YES, [mtlc.composite getExtraAlpha],
+                       &srcFlags,
+                       &renderOptions->dstFlags);
     }
 
     id <MTLRenderPipelineState> pipelineState = [pipelineStateStorage getPipelineState:rpDesc

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPaints.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPaints.m
@@ -725,17 +725,14 @@ jint _color;
         fragShader = @"frag_txt_tp";
         rpDesc = [[templateTexturePipelineDesc copy] autorelease];
         [encoder setFragmentTexture:_paintTexture atIndex:1];
-        setTxtUniforms(encoder, 0, 0, renderOptions->interpolation, YES, [mtlc.composite getExtraAlpha],
-                   &renderOptions->srcFlags, &renderOptions->dstFlags);
     } else {
         rpDesc = [[templateRenderPipelineDesc copy] autorelease];
         [encoder setFragmentTexture:_paintTexture atIndex:0];
-        const SurfaceRasterFlags srcFlags = {_isOpaque, renderOptions->srcFlags.isPremultiplied};
-        setTxtUniforms(encoder, 0, 0,
-                       renderOptions->interpolation, YES, [mtlc.composite getExtraAlpha],
-                       &srcFlags,
-                       &renderOptions->dstFlags);
     }
+    const SurfaceRasterFlags srcFlags = {_isOpaque, renderOptions->srcFlags.isPremultiplied};
+    setTxtUniforms(encoder, 0, 0,
+                   renderOptions->interpolation, YES, [mtlc.composite getExtraAlpha],
+                   &srcFlags, &renderOptions->dstFlags);
 
     id <MTLRenderPipelineState> pipelineState = [pipelineStateStorage getPipelineState:rpDesc
                                                                         vertexShaderId:vertShader


### PR DESCRIPTION
Add alpha to TexturePaint

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (3/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8238533](https://bugs.openjdk.java.net/browse/JDK-8238533): [Lanai] Support texture paint where source is transparent


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/125/head:pull/125`
`$ git checkout pull/125`
