### PR TITLE
8251033: Background texture is not visible when Alpha Composite is enabled

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/common.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/common.h
@@ -62,6 +62,7 @@ struct GradFrameUniforms {
     vector_float4 color1;
     vector_float4 color2;
     int isCyclic;
+    float extraAlpha;
 };
 
 struct LinGradFrameUniforms {
@@ -70,6 +71,7 @@ struct LinGradFrameUniforms {
     vector_float4 color[GRAD_MAX_FRACTIONS];
     int numFracts;
     int cycleMethod;
+    float extraAlpha;
 };
 
 struct RadGradFrameUniforms {
@@ -80,6 +82,7 @@ struct RadGradFrameUniforms {
     vector_float3 m0;
     vector_float3 m1;
     vector_float3 precalc;
+    float extraAlpha;
 };
 
 struct Vertex {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/shaders.metal
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/shaders.metal
@@ -289,7 +289,7 @@ fragment half4 frag_txt_grad(GradShaderInOut in [[stage_in]],
     return half4(c.r*renderColor.a,
                  c.g*renderColor.a,
                  c.b*renderColor.a,
-                 c.a*renderColor.a);
+                 c.a*renderColor.a) * uniforms.extraAlpha;
 }
 
 fragment half4 frag_txt_lin_grad(GradShaderInOut in [[stage_in]],
@@ -325,7 +325,7 @@ fragment half4 frag_txt_lin_grad(GradShaderInOut in [[stage_in]],
     return half4(c.r*renderColor.a,
                  c.g*renderColor.a,
                  c.b*renderColor.a,
-                 c.a*renderColor.a);
+                 c.a*renderColor.a) * uniforms.extraAlpha;
 }
 
 fragment half4 frag_txt_rad_grad(GradShaderInOut in [[stage_in]],
@@ -365,7 +365,7 @@ fragment half4 frag_txt_rad_grad(GradShaderInOut in [[stage_in]],
     return half4(c.r*renderColor.a,
                      c.g*renderColor.a,
                      c.b*renderColor.a,
-                     c.a*renderColor.a);
+                     c.a*renderColor.a) * uniforms.extraAlpha;
 }
 
 
@@ -517,7 +517,7 @@ fragment half4 frag_grad(GradShaderInOut in [[stage_in]],
         }
     }
     float4 c = mix(uniforms.color1, uniforms.color2, a);
-    return half4(c);
+    return half4(c) * uniforms.extraAlpha;
 }
 
 // LinGradFrameUniforms
@@ -544,7 +544,7 @@ fragment half4 frag_lin_grad(GradShaderInOut in [[stage_in]],
     }
     a = (a - n*lf)/lf;
     float4 c = mix(uniforms.color[n], uniforms.color[n + 1], a);
-    return half4(c);
+    return half4(c) * uniforms.extraAlpha;
 }
 
 fragment half4 frag_rad_grad(GradShaderInOut in [[stage_in]],
@@ -574,7 +574,7 @@ fragment half4 frag_rad_grad(GradShaderInOut in [[stage_in]],
     }
     a = (a - n*lf)/lf;
     float4 c = mix(uniforms.color[n], uniforms.color[n + 1], a);
-    return half4(c);
+    return half4(c) * uniforms.extraAlpha;
 }
 
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPaints.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPaints.m
@@ -324,7 +324,8 @@ jint _color;
             {_p0, _p1, _p3},
             RGBA_TO_V4(_pixel1),
             RGBA_TO_V4(_pixel2),
-            _cyclic
+            _cyclic,
+            [mtlc.composite getExtraAlpha]
     };
     [encoder setFragmentBytes:&uf length:sizeof(uf) atIndex:0];
 
@@ -361,7 +362,8 @@ jint _color;
             {_p0, _p1, _p3},
             RGBA_TO_V4(_pixel1 ^ xorColor),
             RGBA_TO_V4(_pixel2 ^ xorColor),
-            _cyclic
+            _cyclic,
+            [mtlc.composite getExtraAlpha]
     };
 
     [encoder setFragmentBytes: &uf length:sizeof(uf) atIndex:0];
@@ -466,7 +468,8 @@ jint _color;
             {},
             {},
             _numFracts,
-            _cyclic
+            _cyclic,
+            [mtlc.composite getExtraAlpha]
     };
 
     memcpy(uf.fract, _fract, _numFracts*sizeof(jfloat));
@@ -629,7 +632,8 @@ jint _color;
             _cyclic,
             {_m00, _m01, _m02},
             {_m10, _m11, _m12},
-            {}
+            {},
+            [mtlc.composite getExtraAlpha]
     };
 
     uf.precalc[0] = _focusX;


### PR DESCRIPTION
Add alpha to Gradient paint

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Testing

|     | Linux x64 | Linux x86 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- | ----- |
| Build | ⏳ (4/5 running) | ⏳ (2/2 running) | ⏳ (2/2 running) | ⏳ (2/2 running) |

### Issue
 * [JDK-8251033](https://bugs.openjdk.java.net/browse/JDK-8251033): Background texture is not visible when Alpha Composite is enabled


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/126/head:pull/126`
`$ git checkout pull/126`
