### PR TITLE
8257566: Lanai: System runs out of application memory while running the Unmanaged_BufferredImage_draw_NearestNeighbor test multiple times

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
@@ -172,7 +172,7 @@ replaceTextureRegion(MTLContext *mtlc, id<MTLTexture> dest, const SurfaceDataRas
                     dw, dh, dx1, dy1);
         // NOTE: we might want to fill alpha channel when !rfi->hasAlpha
 
-        id<MTLBuffer> buff = [mtlc.device newBufferWithLength:(sw * sh * srcInfo->pixelStride) options:MTLResourceStorageModeManaged];
+        id<MTLBuffer> buff = [[mtlc.device newBufferWithLength:(sw * sh * srcInfo->pixelStride) options:MTLResourceStorageModeManaged] autorelease];
 
         // copy src pixels inside src bounds to buff
         for (int row = 0; row < sh; row++) {
@@ -182,7 +182,7 @@ replaceTextureRegion(MTLContext *mtlc, id<MTLTexture> dest, const SurfaceDataRas
         [buff didModifyRange:NSMakeRange(0, buff.length)];
 
         if (rfi->swizzleKernel != nil) {
-            id <MTLBuffer> swizzled = [mtlc.device newBufferWithLength:(sw * sh * srcInfo->pixelStride) options:MTLResourceStorageModeManaged];
+            id <MTLBuffer> swizzled = [[mtlc.device newBufferWithLength:(sw * sh * srcInfo->pixelStride) options:MTLResourceStorageModeManaged] autorelease];
 
             // this should be cheap, since data is already on GPU
             id<MTLCommandBuffer> cb = [mtlc createCommandBuffer];


### PR DESCRIPTION
This PR fixes a memory leak introduced recently.
It was introduced by the fix of JDK-8238285 and missed to be corrected in the fix of JDK-8257413.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8257566](https://bugs.openjdk.java.net/browse/JDK-8257566): Lanai:  System runs out of application memory while running the Unmanaged_BufferredImage_draw_NearestNeighbor test multiple times


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/137/head:pull/137`
`$ git checkout pull/137`
