### PR TITLE
8257886 Build issue in macOS 10.14

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
@@ -232,8 +232,8 @@ MTLBlitSwToTextureViaPooledTexture(
     int sw = srcInfo->bounds.x2 - srcInfo->bounds.x1;
     int sh = srcInfo->bounds.y2 - srcInfo->bounds.y1;
 
-    sw = MIN(sw, mtlc.maxTextureSize);
-    sh = MIN(sh, mtlc.maxTextureSize);
+    sw = MIN(sw, MTL_GPU_FAMILY_MAC_TXT_SIZE);
+    sh = MIN(sh, MTL_GPU_FAMILY_MAC_TXT_SIZE);
 
     id<MTLTexture> dest = bmtlsdOps->pTexture;
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.h
@@ -40,10 +40,9 @@
 #include "MTLClip.h"
 #include "EncoderManager.h"
 
-// Constants from
+// Constant from
 // https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
-#define MTL_GPU_FAMILY_APPLE_1_TXT_SIZE 8192
-#define MTL_GPU_FAMILY_APPLE_3_TXT_SIZE 16384
+#define MTL_GPU_FAMILY_MAC_TXT_SIZE 16384
 
 /**
  * The MTLCommandBufferWrapper class contains command buffer and
@@ -71,7 +70,6 @@
 @property jboolean      aaEnabled;
 
 @property (readonly, strong)   id<MTLDevice>   device;
-@property (readonly) jint                      maxTextureSize;
 @property (strong) id<MTLLibrary>              library;
 @property (strong) id<MTLCommandQueue>         commandQueue;
 @property (strong) id<MTLCommandQueue>         blitCommandQueue;

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
@@ -115,7 +115,7 @@ MTLTransform* tempTransform = nil;
 @synthesize textureFunction,
             vertexCacheEnabled, aaEnabled, device, library, pipelineStateStorage,
             commandQueue, blitCommandQueue, vertexBuffer,
-            texturePool, paint=_paint, maxTextureSize;
+            texturePool, paint=_paint;
 
 extern void initSamplers(id<MTLDevice> device);
 
@@ -124,13 +124,6 @@ extern void initSamplers(id<MTLDevice> device);
     if (self) {
         // Initialization code here.
         device = d;
-        if (@available(macOS 10.15, *)) {
-            maxTextureSize = [d supportsFamily:MTLGPUFamilyApple3] ?
-                    MTL_GPU_FAMILY_APPLE_3_TXT_SIZE : MTL_GPU_FAMILY_APPLE_1_TXT_SIZE;
-        } else {
-            maxTextureSize = MTL_GPU_FAMILY_APPLE_1_TXT_SIZE;
-        }
-
         texturePool = [[MTLTexturePool alloc] initWithDevice:device];
         pipelineStateStorage = [[MTLPipelineStatesStorage alloc] initWithDevice:device shaderLibPath:shadersLib];
 


### PR DESCRIPTION
Replaced detection logic with one constant because we have the same max texture size (16384) for all macs (https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8257886](https://bugs.openjdk.java.net/browse/JDK-8257886): Build issue in macOS 10.14


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/143/head:pull/143`
`$ git checkout pull/143`
