### PR TITLE
8258482 Lanai: reduce data for shape clip using bounding box 

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLClip.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLClip.h
@@ -22,9 +22,12 @@ enum Clip {
  * */
 
 @interface MTLClip : NSObject
-@property (readonly) id<MTLTexture> stencilAADataRef;
 @property (readonly) id<MTLTexture> stencilTextureRef;
 @property (readonly) BOOL stencilMaskGenerationInProgress;
+@property NSUInteger shapeX;
+@property NSUInteger shapeY;
+@property NSUInteger shapeWidth;
+@property NSUInteger shapeHeight;
 
 - (id)init;
 - (BOOL)isEqual:(MTLClip *)other; // used to compare requested with cached


### PR DESCRIPTION
Limiting shape clip data to the bounding box of the clip and using the clearing render pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8258482](https://bugs.openjdk.java.net/browse/JDK-8258482): Lanai: reduce data for shape clip using bounding box 


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/145/head:pull/145`
`$ git checkout pull/145`
