### PR TITLE
8258202: Lanai: Buffered image loses its shape after clicking on Alpha Composite option

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/shaders.metal
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/shaders.metal
@@ -617,6 +617,16 @@ kernel void stencil2tex(const device uchar *imageBuffer [[buffer(0)]],
 
 // work item deals with 4 byte pixel
 // assuming that data is aligned
+kernel void rgb_to_rgba(const device uchar *imageBuffer [[buffer(0)]],
+                        device uchar *outputBuffer [[buffer(1)]],
+                        uint gid [[thread_position_in_grid]])
+{
+    outputBuffer[4 * gid]     = imageBuffer[4 * gid];     // r
+    outputBuffer[4 * gid + 1] = imageBuffer[4 * gid + 1]; // g
+    outputBuffer[4 * gid + 2] = imageBuffer[4 * gid + 2]; // b
+    outputBuffer[4 * gid + 3] = 255;                      // a
+}
+
 kernel void bgr_to_rgba(const device uchar *imageBuffer [[buffer(0)]],
                         device uchar *outputBuffer [[buffer(1)]],
                         uint gid [[thread_position_in_grid]])


### PR DESCRIPTION
Fill alpha channel for RGB BufferedImages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issues
 * [JDK-8258202](https://bugs.openjdk.java.net/browse/JDK-8258202): Lanai: Buffered image loses its shape after clicking on Alpha Composite option
 * [JDK-8252950](https://bugs.openjdk.java.net/browse/JDK-8252950): Lanai : sun/java2d/DirectX/OpaqueImageToSurfaceBlitTest/OpaqueImageToSurfaceBlitTest.java fails 


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/153/head:pull/153`
`$ git checkout pull/153`
