### PR TITLE
8260000: Remove JNF_COCOA_ENTER/EXIT usage from MTLGraphicsConfig.m

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLGraphicsConfig.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLGraphicsConfig.m
@@ -115,7 +115,7 @@ Java_sun_java2d_metal_MTLGraphicsConfig_tryLoadMetalLibrary
     (JNIEnv *env, jclass mtlgc, jint displayID, jstring shadersLibName)
 {
   jboolean ret = JNI_FALSE;
-  JNF_COCOA_ENTER(env);
+  JNI_COCOA_ENTER(env);
   NSMutableArray * retArray = [NSMutableArray arrayWithCapacity:3];
   [retArray addObject: [NSNumber numberWithInt: (int)displayID]];
   [retArray addObject: [NSString stringWithUTF8String: JNU_GetStringPlatformChars(env, shadersLibName, 0)]];
@@ -126,7 +126,7 @@ Java_sun_java2d_metal_MTLGraphicsConfig_tryLoadMetalLibrary
   }
   NSNumber * num = (NSNumber *)[retArray objectAtIndex: 0];
   ret = (jboolean)[num boolValue];
-  JNF_COCOA_EXIT(env);
+  JNI_COCOA_EXIT(env);
   return ret;
 }
 


### PR DESCRIPTION
Usage of JNF_COCOA_ENTER/EXIT was replaced in Lanai code-base under JDK-8259939, but fix of JDK-8258754 has introduced an instance in MTLGraphicsConfig.m. It needs to be replaced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8260000](https://bugs.openjdk.java.net/browse/JDK-8260000): Remove JNF_COCOA_ENTER/EXIT usage from MTLGraphicsConfig.m


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/156/head:pull/156`
`$ git checkout pull/156`
