### PR TITLE
8258658: Print log that metal pipeline is enabled when -Dsun.java2d.metal=True is set

### DIFF
--- a/src/java.desktop/macosx/classes/sun/awt/CGraphicsDevice.java
+++ b/src/java.desktop/macosx/classes/sun/awt/CGraphicsDevice.java
@@ -113,6 +113,12 @@ public final class CGraphicsDevice extends GraphicsDevice
             throw new InternalError("Error - unable to initialize any rendering pipeline.");
         }
 
+        if (metalPipelineEnabled && MacOSFlags.isMetalVerbose()) {
+            System.out.println("Metal pipeline enabled on screen " + displayID);
+        } else if (oglPipelineEnabled && MacOSFlags.isOGLVerbose()) {
+            System.out.println("OpenGL pipeline enabled on screen " + displayID);
+        }
+
         // initializes default device state, might be redundant step since we
         // call "displayChanged()" later anyway, but we do not want to leave the
         // device in an inconsistent state after construction


### PR DESCRIPTION
Added printing name of the rendering pipeline in use (only in verbose mode)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8258658](https://bugs.openjdk.java.net/browse/JDK-8258658): Print log that metal pipeline is enabled when -Dsun.java2d.metal=True is set


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/157/head:pull/157`
`$ git checkout pull/157`
