### PR TITLE
8252952: Lanai: VolatileImage/BitmaskVolatileImage test fails

### DIFF
--- a/src/java.desktop/macosx/classes/sun/java2d/metal/MTLGraphicsConfig.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/metal/MTLGraphicsConfig.java
@@ -49,7 +49,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 
 import static sun.java2d.metal.MTLContext.MTLContextCaps.CAPS_EXT_GRAD_SHADER;
-import static sun.java2d.opengl.OGLSurfaceData.TEXTURE;
+import static sun.java2d.pipe.hw.AccelSurface.TEXTURE;
 import static sun.java2d.pipe.hw.AccelSurface.RT_TEXTURE;
 import static sun.java2d.pipe.hw.ContextCapabilities.*;
 
@@ -372,7 +372,8 @@ public final class MTLGraphicsConfig extends CGraphicsConfig
     public VolatileImage createCompatibleVolatileImage(int width, int height,
                                                        int transparency,
                                                        int type) {
-        if (type != RT_TEXTURE && type != TEXTURE) {
+        if ((type != RT_TEXTURE && type != TEXTURE) ||
+            transparency == Transparency.BITMASK) {
             return null;
         }
 


### PR DESCRIPTION
VolatileImage with transparency Transparency.BITMASK should not be accelerated. Minor cleanup

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8252952](https://bugs.openjdk.java.net/browse/JDK-8252952): Lanai: VolatileImage/BitmaskVolatileImage test fails 


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/158/head:pull/158`
`$ git checkout pull/158`
