### PR TITLE
8260582: Clean up MacOSFlags implementation

### DIFF
--- a/src/java.desktop/macosx/classes/sun/awt/CGraphicsDevice.java
+++ b/src/java.desktop/macosx/classes/sun/awt/CGraphicsDevice.java
@@ -37,7 +37,7 @@ import java.awt.peer.WindowPeer;
 import java.util.Objects;
 
 import sun.java2d.SunGraphicsEnvironment;
-import sun.java2d.macos.MacOSFlags;
+import sun.java2d.MacOSFlags;
 import sun.java2d.metal.MTLGraphicsConfig;
 import sun.java2d.opengl.CGLGraphicsConfig;
 

--- a/src/java.desktop/macosx/classes/sun/java2d/MacOSFlags.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/MacOSFlags.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-package sun.java2d.macos;
+package sun.java2d;
 
 import java.security.PrivilegedAction;
 import sun.java2d.metal.MTLGraphicsConfig;
@@ -47,10 +47,7 @@ public class MacOSFlags {
 
     static {
         initJavaFlags();
-        initNativeFlags();
     }
-
-    private static native boolean initNativeFlags();
 
     private static PropertyState getBooleanProp(String p, PropertyState defaultVal) {
         String propString = System.getProperty(p);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,6 @@
 
 // keyboard layout
 static NSString *kbdLayout;
-jboolean metalEnabled = JNI_FALSE;
 
 @interface AWTView()
 @property (retain) CDropTarget *_dropTarget;
@@ -56,9 +55,6 @@ jboolean metalEnabled = JNI_FALSE;
 //#define IM_DEBUG TRUE
 //#define EXTRA_DEBUG
 
-// Uncomment this line to see Metal specific fprintfs
-//#define METAL_DEBUG
-
 static BOOL shouldUsePressAndHold() {
     return YES;
 }
@@ -69,7 +65,6 @@ static BOOL shouldUsePressAndHold() {
 @synthesize _dragSource;
 @synthesize cglLayer;
 @synthesize mouseIsOver;
-
 
 // Note: Must be called on main (AppKit) thread only
 - (id) initWithRect: (NSRect) rect
@@ -1535,20 +1530,4 @@ JNIEXPORT jboolean JNICALL Java_sun_lwawt_macosx_CPlatformView_nativeIsViewUnder
     JNI_COCOA_EXIT(env);
 
     return underMouse;
-}
-
-jboolean GetStaticBoolean(JNIEnv *env, jclass fClass, const char *fieldName)
-{
-    jfieldID fieldID = (*env)->GetStaticFieldID(env, fClass, fieldName, "Z");
-    return (*env)->GetStaticBooleanField(env, fClass, fieldID);
-}
-
-JNIEXPORT void JNICALL
-Java_sun_java2d_macos_MacOSFlags_initNativeFlags(JNIEnv *env,
-                                                     jclass flagsClass)
-{
-  metalEnabled = GetStaticBoolean(env, flagsClass, "metalEnabled");
-#ifdef METAL_DEBUG
-  fprintf(stderr, "metalEnabled=%d\n", metalEnabled);
-#endif
 }


### PR DESCRIPTION
Changes -
- Its path has two "macos" directories. Last one is removed as MacOSFlags.java is the only file in it. File is moved one directory up.

- Removed unused native method --> it results in undoing the changes in AWTView.m so that it becomes the same as in openjdk/jdk

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8260582](https://bugs.openjdk.java.net/browse/JDK-8260582): Clean up MacOSFlags implementation


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/162/head:pull/162`
`$ git checkout pull/162`
