### PR TITLE
8260553: Lanai: pipeline substates use while loop for resize

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPipelineStatesStorage.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPipelineStatesStorage.m
@@ -141,8 +141,9 @@ static void setBlendingFactors(
     int index = compositeRule*64 + subIndex;
 
     NSPointerArray * subStates = [self getSubStates:vertexShaderId fragmentShader:fragmentShaderId];
-    while (index >= [subStates count]) {
-        [subStates addPointer:NULL]; // obj-c collections haven't resize methods, so do that
+
+    if (index >= subStates.count) {
+        subStates.count = (NSUInteger) (index + 1);
     }
 
     id<MTLRenderPipelineState> result = [subStates pointerAtIndex:index];


### PR DESCRIPTION
Replaced while with the setting the count property

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8260553](https://bugs.openjdk.java.net/browse/JDK-8260553): Lanai: pipeline substates use while loop for resize


### Reviewers
 * dkonoplev - Committer ⚠️ Added manually

### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/163/head:pull/163`
`$ git checkout pull/163`
