### PR TITLE
8261430: Remove redundant #ifndef HEADLESS checks from metal native code

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
@@ -23,8 +23,6 @@
  * questions.
  */
 
-#ifndef HEADLESS
-
 #include <jni.h>
 #include <jlong.h>
 
@@ -779,5 +777,3 @@ MTLBlitLoops_CopyArea(JNIEnv *env,
     // TODO:
     //  1. check rect bounds
 }
-
-#endif /* !HEADLESS */

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBufImgOps.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBufImgOps.m
@@ -23,8 +23,6 @@
  * questions.
  */
 
-#ifndef HEADLESS
-
 #include <jlong.h>
 
 #include "MTLBufImgOps.h"
@@ -223,5 +221,3 @@
 }
 
 @end
-
-#endif /* !HEADLESS */

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
@@ -23,8 +23,6 @@
  * questions.
  */
 
-#ifndef HEADLESS
-
 #include <stdlib.h>
 
 #include "sun_java2d_SunGraphics2D.h"
@@ -439,5 +437,3 @@ extern void initSamplers(id<MTLDevice> device);
 }
 
 @end
-
-#endif /* !HEADLESS */

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLMaskBlit.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLMaskBlit.m
@@ -23,8 +23,6 @@
  * questions.
  */
 
-#ifndef HEADLESS
-
 #include <stdlib.h>
 #include <jlong.h>
 
@@ -70,5 +68,3 @@ MTLMaskBlit_MaskBlit(JNIEnv *env, MTLContext *mtlc, BMTLSDOps * dstOps,
     drawTex2Tex(mtlc, texBuff, dstOps->pTexture, JNI_FALSE, dstOps->isOpaque, 0,
                 0, 0, width, height, dstx, dsty, dstx + width, dsty + height);
 }
-
-#endif /* !HEADLESS */

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLMaskFill.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLMaskFill.m
@@ -23,8 +23,6 @@
  * questions.
  */
 
-#ifndef HEADLESS
-
 #include "sun_java2d_metal_MTLMaskFill.h"
 
 #include "MTLMaskFill.h"
@@ -114,5 +112,3 @@ Java_sun_java2d_metal_MTLMaskFill_maskFill
         (*env)->ReleasePrimitiveArrayCritical(env, maskArray, mask, JNI_ABORT);
     }
 }
-
-#endif /* !HEADLESS */

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPaints.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPaints.m
@@ -23,12 +23,8 @@
  * questions.
  */
 
-#ifndef HEADLESS
-
 #include "MTLPaints.h"
-
 #include "MTLClip.h"
-
 #include "common.h"
 
 #include "sun_java2d_SunGraphics2D.h"
@@ -991,4 +987,3 @@ static void setTxtUniforms(
 }
 
 @end
-#endif /* !HEADLESS */

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderQueue.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderQueue.m
@@ -23,8 +23,6 @@
  * questions.
  */
 
-#ifndef HEADLESS
-
 #include <stdlib.h>
 
 #include "sun_java2d_pipe_BufferedOpCodes.h"
@@ -947,5 +945,3 @@ void commitEncodedCommands() {
     [commandbuf commit];
     [commandbuf waitUntilCompleted];
 }
-
-#endif /* !HEADLESS */

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderer.m
@@ -23,8 +23,6 @@
  * questions.
  */
 
-#ifndef HEADLESS
-
 #include <jlong.h>
 #include <jni_util.h>
 #include <math.h>
@@ -954,4 +952,3 @@ MTLRenderer_DrawAAParallelogram(MTLContext *mtlc, BMTLSDOps * dstOps,
                                         odx12, ody12);
     }
 }
-#endif /* !HEADLESS */

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLTextRenderer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLTextRenderer.m
@@ -23,8 +23,6 @@
  * questions.
  */
 
-#ifndef HEADLESS
-
 #include <stdlib.h>
 #include <limits.h>
 #include <math.h>
@@ -894,5 +892,3 @@ Java_sun_java2d_metal_MTLTextRenderer_drawGlyphList
                                               images, JNI_ABORT);
     }
 }
-
-#endif /* !HEADLESS */

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
@@ -23,8 +23,6 @@
  * questions.
  */
 
-#ifndef HEADLESS
-
 #include <stdlib.h>
 #include <string.h>
 
@@ -316,5 +314,3 @@ MTLVertexCache_AddGlyphQuad(MTLContext *mtlc,
     MTLVC_ADD_TRIANGLES(tx1, ty1, tx2, ty2,
                         dx1, dy1, dx2, dy2);
 }
-
-#endif /* !HEADLESS */


### PR DESCRIPTION
Files in macosx/native/libawt_lwawt/java2d/metal directory have redundant #ifndef HEADLESS checks which are removed.
 
This was identified as part of code review in https://github.com/openjdk/jdk/pull/2403

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261430](https://bugs.openjdk.java.net/browse/JDK-8261430): Remove redundant #ifndef HEADLESS checks from metal native code


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/177/head:pull/177`
`$ git checkout pull/177`
