### PR TITLE
8261402: Verify whether we need ContextCaps in metal

### DIFF
--- a/src/java.desktop/macosx/classes/sun/java2d/metal/MTLContext.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/metal/MTLContext.java
@@ -128,11 +128,6 @@ final class MTLContext extends BufferedContext {
          */
         @Native
         static final int CAPS_EXT_GRAD_SHADER  = (FIRST_PRIVATE_CAP << 3);
-        @Native
-        static final int CAPS_EXT_TEXRECT      = (FIRST_PRIVATE_CAP << 4);
-        @Native
-        static final int CAPS_EXT_TEXBARRIER = (FIRST_PRIVATE_CAP << 5);
-
 
         public MTLContextCaps(int caps, String adapterId) {
             super(caps, adapterId);
@@ -152,12 +147,6 @@ final class MTLContext extends BufferedContext {
             }
             if ((caps & CAPS_EXT_GRAD_SHADER) != 0) {
                 sb.append("CAPS_EXT_GRAD_SHADER|");
-            }
-            if ((caps & CAPS_EXT_TEXRECT) != 0) {
-                sb.append("CAPS_EXT_TEXRECT|");
-            }
-            if ((caps & CAPS_EXT_TEXBARRIER) != 0) {
-                sb.append("CAPS_EXT_TEXBARRIER|");
             }
             return sb.toString();
         }


### PR DESCRIPTION
Removed unnecessary CAPs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261402](https://bugs.openjdk.java.net/browse/JDK-8261402): Verify whether we need ContextCaps in metal


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/179/head:pull/179`
`$ git checkout pull/179`
