### PR TITLE
8261143: Code in MTLGraphicsConfig.m can use ThreadUtilities performOnMainThreadWaiting:YES block:^()

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLGraphicsConfig.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLGraphicsConfig.m
@@ -113,20 +113,20 @@ JNIEXPORT jboolean JNICALL
 Java_sun_java2d_metal_MTLGraphicsConfig_tryLoadMetalLibrary
     (JNIEnv *env, jclass mtlgc, jint displayID, jstring shadersLibName)
 {
-  jboolean ret = JNI_FALSE;
-  JNI_COCOA_ENTER(env);
-  NSMutableArray * retArray = [NSMutableArray arrayWithCapacity:3];
-  [retArray addObject: [NSNumber numberWithInt: (int)displayID]];
-  [retArray addObject: [NSString stringWithUTF8String: JNU_GetStringPlatformChars(env, shadersLibName, 0)]];
-  if ([NSThread isMainThread]) {
-      [MTLGraphicsConfigUtil _tryLoadMetalLibrary: retArray];
-  } else {
-      [MTLGraphicsConfigUtil performSelectorOnMainThread: @selector(_tryLoadMetalLibrary:) withObject: retArray waitUntilDone: YES];
-  }
-  NSNumber * num = (NSNumber *)[retArray objectAtIndex: 0];
-  ret = (jboolean)[num boolValue];
-  JNI_COCOA_EXIT(env);
-  return ret;
+    jboolean ret = JNI_FALSE;
+    JNI_COCOA_ENTER(env);
+    NSMutableArray * retArray = [NSMutableArray arrayWithCapacity:3];
+    [retArray addObject: [NSNumber numberWithInt: (int)displayID]];
+    [retArray addObject: [NSString stringWithUTF8String: JNU_GetStringPlatformChars(env, shadersLibName, 0)]];
+
+    [ThreadUtilities performOnMainThreadWaiting:YES block:^() {
+        [MTLGraphicsConfigUtil _tryLoadMetalLibrary: retArray];
+    }];
+
+    NSNumber * num = (NSNumber *)[retArray objectAtIndex: 0];
+    ret = (jboolean)[num boolValue];
+    JNI_COCOA_EXIT(env);
+    return ret;
 }
 
 
@@ -144,20 +144,20 @@ JNIEXPORT jlong JNICALL
 Java_sun_java2d_metal_MTLGraphicsConfig_getMTLConfigInfo
     (JNIEnv *env, jclass mtlgc, jint displayID, jstring mtlShadersLib)
 {
-  jlong ret = 0L;
-  JNI_COCOA_ENTER(env);
-  NSMutableArray * retArray = [NSMutableArray arrayWithCapacity:3];
-  [retArray addObject: [NSNumber numberWithInt: (int)displayID]];
-  [retArray addObject: [NSString stringWithUTF8String: JNU_GetStringPlatformChars(env, mtlShadersLib, 0)]];
-  if ([NSThread isMainThread]) {
-      [MTLGraphicsConfigUtil _getMTLConfigInfo: retArray];
-  } else {
-      [MTLGraphicsConfigUtil performSelectorOnMainThread: @selector(_getMTLConfigInfo:) withObject: retArray waitUntilDone: YES];
-  }
-  NSNumber * num = (NSNumber *)[retArray objectAtIndex: 0];
-  ret = (jlong)[num longValue];
-  JNI_COCOA_EXIT(env);
-  return ret;
+    jlong ret = 0L;
+    JNI_COCOA_ENTER(env);
+    NSMutableArray * retArray = [NSMutableArray arrayWithCapacity:3];
+    [retArray addObject: [NSNumber numberWithInt: (int)displayID]];
+    [retArray addObject: [NSString stringWithUTF8String: JNU_GetStringPlatformChars(env, mtlShadersLib, 0)]];
+
+    [ThreadUtilities performOnMainThreadWaiting:YES block:^() {
+        [MTLGraphicsConfigUtil _getMTLConfigInfo: retArray];
+    }];
+
+    NSNumber * num = (NSNumber *)[retArray objectAtIndex: 0];
+    ret = (jlong)[num longValue];
+    JNI_COCOA_EXIT(env);
+    return ret;
 }
 
 


### PR DESCRIPTION
1) Simplified code in MTLGraphicsConfig.m
2) Corrected method code spacing to 4 spaces from 2 spaces.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261143](https://bugs.openjdk.java.net/browse/JDK-8261143): Code in MTLGraphicsConfig.m can use ThreadUtilities performOnMainThreadWaiting:YES block:^()


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/181/head:pull/181`
`$ git checkout pull/181`
