### PR TITLE
8261620: Running metal with API validation crashes immediately

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLLayer.m
@@ -91,6 +91,17 @@
             J2dTraceLn(J2D_TRACE_VERBOSE, "MTLLayer.blitTexture: cannot create drawable of size 0");
             return;
         }
+
+        NSUInteger src_x = self.leftInset * self.contentsScale;
+        NSUInteger src_y = self.topInset * self.contentsScale;
+        NSUInteger src_w = self.buffer.width - src_x;
+        NSUInteger src_h = self.buffer.height - src_y;
+
+        if (src_h <= 0 || src_w <= 0) {
+           J2dTraceLn(J2D_TRACE_VERBOSE, "MTLLayer.blitTexture: Invalid src width or height.");
+           return;
+        }
+
         id<MTLCommandBuffer> commandBuf = [self.ctx createBlitCommandBuffer];
         if (commandBuf == nil) {
             J2dTraceLn(J2D_TRACE_VERBOSE, "MTLLayer.blitTexture: commandBuf is null");
@@ -102,12 +113,13 @@
             return;
         }
         self.nextDrawableCount++;
+
         id <MTLBlitCommandEncoder> blitEncoder = [commandBuf blitCommandEncoder];
 
         [blitEncoder
                 copyFromTexture:self.buffer sourceSlice:0 sourceLevel:0
-                sourceOrigin:MTLOriginMake((jint)(self.leftInset*self.contentsScale), (jint)(self.topInset*self.contentsScale), 0)
-                sourceSize:MTLSizeMake(self.buffer.width, self.buffer.height, 1)
+                sourceOrigin:MTLOriginMake(src_x, src_y, 0)
+                sourceSize:MTLSizeMake(src_w, src_h, 1)
                 toTexture:mtlDrawable.texture destinationSlice:0 destinationLevel:0 destinationOrigin:MTLOriginMake(0, 0, 0)];
         [blitEncoder endEncoding];
 


### PR DESCRIPTION
Root cause : Trying to copy backbuffer-texture to frontbuffer-texture after accommodating for Insets causes some overflow which is detected only with Metal API validation.

Fix : Adjusted texture size to be copied to accommodate insets.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261620](https://bugs.openjdk.java.net/browse/JDK-8261620): Running metal with API validation crashes immediately


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/184/head:pull/184`
`$ git checkout pull/184`
