### PR TITLE
8261638: Lanai: crash in Clipping tab of J2Demo

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPipelineStatesStorage.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPipelineStatesStorage.h
@@ -59,6 +59,11 @@ NSMutableDictionary<NSString*, id<MTLComputePipelineState>> * computeStates;
 - (id<MTLRenderPipelineState>) getPipelineState:(MTLRenderPipelineDescriptor *) pipelineDescriptor
                                  vertexShaderId:(NSString *)vertexShaderId
                                fragmentShaderId:(NSString *)fragmentShaderId
+                                  stencilNeeded:(bool)stencilNeeded;
+
+- (id<MTLRenderPipelineState>) getPipelineState:(MTLRenderPipelineDescriptor *) pipelineDescriptor
+                                 vertexShaderId:(NSString *)vertexShaderId
+                               fragmentShaderId:(NSString *)fragmentShaderId
                                       composite:(MTLComposite*)composite
                                   renderOptions:(const RenderOptions *)renderOptions
                                   stencilNeeded:(bool)stencilNeeded;

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPipelineStatesStorage.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPipelineStatesStorage.m
@@ -93,6 +93,20 @@ static void setBlendingFactors(
                     stencilNeeded:NO];
 }
 
+- (id<MTLRenderPipelineState>) getPipelineState:(MTLRenderPipelineDescriptor *) pipelineDescriptor
+                                 vertexShaderId:(NSString *)vertexShaderId
+                               fragmentShaderId:(NSString *)fragmentShaderId
+                               stencilNeeded:(bool)stencilNeeded
+{
+    RenderOptions defaultOptions = {JNI_FALSE, JNI_FALSE, 0/*unused*/, {JNI_FALSE, JNI_TRUE}, {JNI_FALSE, JNI_TRUE}, JNI_FALSE};
+    return [self getPipelineState:pipelineDescriptor
+                   vertexShaderId:vertexShaderId
+                 fragmentShaderId:fragmentShaderId
+                        composite:nil
+                    renderOptions:&defaultOptions
+                    stencilNeeded:stencilNeeded];
+}
+
 // Base method to obtain MTLRenderPipelineState.
 // NOTE: parameters compositeRule, srcFlags, dstFlags are used to set MTLRenderPipelineColorAttachmentDescriptor multipliers
 - (id<MTLRenderPipelineState>) getPipelineState:(MTLRenderPipelineDescriptor *) pipelineDescriptor

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderer.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderer.m
@@ -714,8 +714,9 @@ setupAAShaderState(id<MTLRenderCommandEncoder> encoder,
     id<MTLRenderPipelineState> pipelineState =
                 [mtlc.pipelineStateStorage
                     getPipelineState:templateAAPipelineDesc
-                    vertexShaderId:@"vert_col_aa"
+                      vertexShaderId:@"vert_col_aa"
                     fragmentShaderId:@"frag_col_aa"
+                       stencilNeeded:mtlc.clip.isShape
                    ];
 
     [encoder setRenderPipelineState:pipelineState];


### PR DESCRIPTION
Pass stencilNeeded flag to pipelineStateStorage

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261638](https://bugs.openjdk.java.net/browse/JDK-8261638): Lanai: crash in Clipping tab of J2Demo


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/186/head:pull/186`
`$ git checkout pull/186`
