### PR TITLE
8261712: Lanai: Crash in MTLClip when Metal API Validation enabled

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/EncoderManager.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/EncoderManager.m
@@ -372,7 +372,7 @@ const SurfaceRasterFlags defaultRasterFlags = { JNI_FALSE, JNI_TRUE };
 
   if (_encoder == nil) {
     _destination = dest;
-    _useStencil = [_mtlc.clip isShape];
+    _useStencil = [_mtlc.clip isShape] && !_mtlc.clip.stencilMaskGenerationInProgress;
     forceUpdate = JNI_TRUE;
 
     MTLCommandBufferWrapper *cbw = [_mtlc getCommandBufferWrapper];


### PR DESCRIPTION
Do not use stencil in stencil mask generation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261712](https://bugs.openjdk.java.net/browse/JDK-8261712): Lanai: Crash in MTLClip when Metal API Validation enabled


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/189/head:pull/189`
`$ git checkout pull/189`
