### PR TITLE
8262091: Add RenderPerfTest for XOR mode rendering

### DIFF
--- a/test/jdk/performance/client/RenderPerfTest/src/renderperf/RenderPerfTest.java
+++ b/test/jdk/performance/client/RenderPerfTest/src/renderperf/RenderPerfTest.java
@@ -760,6 +760,15 @@ public class RenderPerfTest {
         g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
                 RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 
+    private static final Configurable XORMode = (Graphics2D g2d) ->
+        {g2d.setXORMode(Color.WHITE);};
+
+    private static final Configurable XORModeLCDText = (Graphics2D g2d) ->
+        {g2d.setXORMode(Color.WHITE);
+         g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+         RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);};
+
+
     public void testFlatOval() throws Exception {
         (new PerfMeter("FlatOval")).exec(createPR(flatRenderer)).report();
     }
@@ -929,6 +938,30 @@ public class RenderPerfTest {
 
     public void testBgrSurfaceBlitImage() throws Exception {
         (new PerfMeter("BgrSurfaceBlitImage")).exec(createPR(bgrSurfaceBlitImageRenderer)).report();
+    }
+
+    public void testFlatOval_XOR() throws Exception {
+        (new PerfMeter("FlatOval_XOR")).exec(createPR(flatRenderer).configure(XORMode)).report();
+    }
+
+    public void testRotatedBox_XOR() throws Exception {
+        (new PerfMeter("RotatedBox_XOR")).exec(createPR(flatBoxRotRenderer).configure(XORMode)).report();
+    }
+
+    public void testLines_XOR() throws Exception {
+        (new PerfMeter("Lines_XOR")).exec(createPR(segRenderer).configure(XORMode)).report();
+    }
+
+    public void testImage_XOR() throws Exception {
+        (new PerfMeter("Image_XOR")).exec(createPR(imgRenderer).configure(XORMode)).report();
+    }
+
+    public void testTextNoAA_XOR() throws Exception {
+        (new PerfMeter("TextNoAA_XOR")).exec(createPR(textRenderer).configure(XORMode)).report();
+    }
+
+    public void testTextLCD_XOR() throws Exception {
+        (new PerfMeter("TextLCD_XOR")).exec(createPR(textRenderer).configure(XORModeLCDText)).report();
     }
 
     public static void main(String[] args)


### PR DESCRIPTION
Add RenderPerfTest for XOR mode rendering of primitives, image and text rendering.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8262091](https://bugs.openjdk.java.net/browse/JDK-8262091): Add RenderPerfTest for XOR mode rendering


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/199/head:pull/199`
`$ git checkout pull/199`
