### PR TITLE
8262115: Crash on graphics card switch when Metal API validation enabled

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLClip.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLClip.h
@@ -65,6 +65,7 @@ enum Clip {
 - (const MTLScissorRect *) getRect;
 
 - (void)reset;
+- (void)resetStencilState;
 - (void)setClipRectX1:(jint)x1 Y1:(jint)y1 X2:(jint)x2 Y2:(jint)y2;
 - (void)beginShapeClip:(BMTLSDOps *)dstOps context:(MTLContext *)mtlc;
 - (void)endShapeClip:(BMTLSDOps *)dstOps context:(MTLContext *)mtlc;

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLClip.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLClip.m
@@ -29,6 +29,7 @@
 #include "common.h"
 
 static MTLRenderPipelineDescriptor * templateStencilPipelineDesc = nil;
+static id<MTLDepthStencilState> stencilState = nil;
 
 static void initTemplatePipelineDescriptors() {
     if (templateStencilPipelineDesc != nil)
@@ -50,7 +51,6 @@ static void initTemplatePipelineDescriptors() {
 }
 
 static id<MTLDepthStencilState> getStencilState(id<MTLDevice> device) {
-    static id<MTLDepthStencilState> stencilState = nil;
     if (stencilState == nil) {
         MTLDepthStencilDescriptor* stencilDescriptor;
         stencilDescriptor = [[MTLDepthStencilDescriptor new] autorelease];
@@ -136,6 +136,13 @@ static id<MTLDepthStencilState> getStencilState(id<MTLDevice> device) {
 - (void)reset {
     _clipType = NO_CLIP;
     _stencilMaskGenerationInProgress = JNI_FALSE;
+}
+
+- (void)resetStencilState {
+    if (stencilState != nil) {
+        [stencilState release];
+        stencilState = nil;
+    }
 }
 
 - (void)setClipRectX1:(jint)x1 Y1:(jint)y1 X2:(jint)x2 Y2:(jint)y2 {

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.h
@@ -172,7 +172,7 @@
                     M01:(jdouble) m01 M11:(jdouble) m11
                     M02:(jdouble) m02 M12:(jdouble) m12;
 
-
+- (void)reset;
 - (void)resetPaint;
 - (void)setColorPaint:(int)pixel;
 - (void)setGradientPaintUseMask:(jboolean)useMask

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
@@ -173,6 +173,13 @@ extern void initSamplers(id<MTLDevice> device);
     [super dealloc];
 }
 
+- (void) reset {
+    J2dTraceLn(J2D_TRACE_VERBOSE, "MTLContext : reset");
+
+    // Add code for context state reset here
+    [_clip resetStencilState];
+}
+
  - (MTLCommandBufferWrapper *) getCommandBufferWrapper {
     if (_commandBufferWrapper == nil) {
         J2dTraceLn(J2D_TRACE_VERBOSE, "MTLContext : commandBuffer is NULL");

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPaints.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPaints.m
@@ -835,6 +835,7 @@ jint _color;
     return @"unknown-paint";
 }
 
+static bool samplersInitialized = false;
 static id<MTLSamplerState> samplerNearestClamp = nil;
 static id<MTLSamplerState> samplerLinearClamp = nil;
 static id<MTLSamplerState> samplerNearestRepeat = nil;
@@ -843,8 +844,15 @@ static id<MTLSamplerState> samplerLinearRepeat = nil;
 void initSamplers(id<MTLDevice> device) {
     // TODO: move this code into SamplerManager (need implement)
 
-    if (samplerNearestClamp != nil)
-        return;
+    if (samplersInitialized) {
+        // Release old samplers if any
+        [samplerNearestClamp release];
+        [samplerLinearClamp release];
+        [samplerNearestRepeat release];
+        [samplerLinearRepeat release];
+
+        samplersInitialized = false;
+    }
 
     MTLSamplerDescriptor *samplerDescriptor = [[MTLSamplerDescriptor new] autorelease];
 
@@ -871,6 +879,8 @@ void initSamplers(id<MTLDevice> device) {
     samplerDescriptor.minFilter = MTLSamplerMinMagFilterLinear;
     samplerDescriptor.magFilter = MTLSamplerMinMagFilterLinear;
     samplerLinearRepeat = [device newSamplerStateWithDescriptor:samplerDescriptor];
+
+    samplersInitialized = true;
 }
 
 static void setSampler(id<MTLRenderCommandEncoder> encoder, int interpolation, bool repeat) {

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderQueue.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderQueue.m
@@ -663,10 +663,18 @@ Java_sun_java2d_metal_MTLRenderQueue_flushBuffer
                     // invalidate the references to the current context and
                     // destination surface that are maintained at the native level
                     if (mtlc != NULL) {
-                        [mtlc.encoderManager endEncoder];
+                        commitEncodedCommands();
+                        RESET_PREVIOUS_OP();
+                        [mtlc reset];
                     }
+
+                    MTLTR_FreeGlyphCaches();
+                    if (dstOps != NULL) {
+                        MTLSD_Delete(env, dstOps);
+                    }
+
                     mtlc = NULL;
-                //    dstOps = NULL;
+                    dstOps = NULL;
                     break;
                 }
                 case sun_java2d_pipe_BufferedOpCodes_SYNC:


### PR DESCRIPTION
First 3 errors observed during testing of JDK-8261714 are being fixed in this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8262115](https://bugs.openjdk.java.net/browse/JDK-8262115): Crash on graphics card switch when Metal API validation enabled


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/200/head:pull/200`
`$ git checkout pull/200`
