### PR TITLE
8261891: sanity/client/SwingSet/src/EditorPaneDemoTest.java fails with Metal API Validation

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/EncoderManager.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/EncoderManager.h
@@ -59,6 +59,8 @@
 - (id<MTLRenderCommandEncoder> _Nonnull)getRenderEncoder:(id<MTLTexture> _Nonnull)dest
                                              isDstOpaque:(bool)isOpaque;
 
+- (id<MTLRenderCommandEncoder> _Nonnull)getAAShaderRenderEncoder:(const BMTLSDOps * _Nonnull)dstOps;
+
 // returns encoder that renders/fills geometry with current composite and with given texture
 // (user must call [encoder setFragmentTexture] before any rendering)
 - (id<MTLRenderCommandEncoder> _Nonnull)getTextureEncoder:(const BMTLSDOps * _Nonnull)dstOps

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPipelineStatesStorage.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLPipelineStatesStorage.m
@@ -84,7 +84,7 @@ static void setBlendingFactors(
                                  vertexShaderId:(NSString *)vertexShaderId
                                fragmentShaderId:(NSString *)fragmentShaderId
 {
-    RenderOptions defaultOptions = {JNI_FALSE, JNI_FALSE, 0/*unused*/, {JNI_FALSE, JNI_TRUE}, {JNI_FALSE, JNI_TRUE}, JNI_FALSE, JNI_FALSE};
+    RenderOptions defaultOptions = {JNI_FALSE, JNI_FALSE, 0/*unused*/, {JNI_FALSE, JNI_TRUE}, {JNI_FALSE, JNI_TRUE}, JNI_FALSE, JNI_FALSE, JNI_FALSE};
     return [self getPipelineState:pipelineDescriptor
                    vertexShaderId:vertexShaderId
                  fragmentShaderId:fragmentShaderId
@@ -98,7 +98,7 @@ static void setBlendingFactors(
                                fragmentShaderId:(NSString *)fragmentShaderId
                                stencilNeeded:(bool)stencilNeeded
 {
-    RenderOptions defaultOptions = {JNI_FALSE, JNI_FALSE, 0/*unused*/, {JNI_FALSE, JNI_TRUE}, {JNI_FALSE, JNI_TRUE}, JNI_FALSE, JNI_FALSE};
+    RenderOptions defaultOptions = {JNI_FALSE, JNI_FALSE, 0/*unused*/, {JNI_FALSE, JNI_TRUE}, {JNI_FALSE, JNI_TRUE}, JNI_FALSE, JNI_FALSE, JNI_FALSE};
     return [self getPipelineState:pipelineDescriptor
                    vertexShaderId:vertexShaderId
                  fragmentShaderId:fragmentShaderId

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/RenderOptions.h
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/RenderOptions.h
@@ -38,6 +38,7 @@ typedef struct {
     SurfaceRasterFlags dstFlags;
     jboolean isText;
     jboolean isLCD;
+    jboolean isAAShader;
 } RenderOptions;
 
 


### PR DESCRIPTION
Refactored AA shader usage. Performed end of AAshader encoder for incompatible rendering modes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8261891](https://bugs.openjdk.java.net/browse/JDK-8261891): sanity/client/SwingSet/src/EditorPaneDemoTest.java fails with Metal API Validation


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/201/head:pull/201`
`$ git checkout pull/201`
