### PR TITLE
8262293: Remove redundant end of encoder for AAShader rendering

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/EncoderManager.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/EncoderManager.m
@@ -366,8 +366,7 @@ const SurfaceRasterFlags defaultRasterFlags = { JNI_FALSE, JNI_TRUE };
   //
   jboolean needEnd = JNI_FALSE;
   if (_encoder != nil) {
-    if (_destination != dest || renderOptions->isAA != _encoderStates.aa ||
-            renderOptions->isAAShader != _encoderStates.aaShader) {
+    if (_destination != dest || renderOptions->isAA != _encoderStates.aa) {
       J2dTraceLn2(J2D_TRACE_VERBOSE,
                   "end common encoder because of dest change: %p -> %p",
                   _destination, dest);


### PR DESCRIPTION
We don't need to end an encoder before/after AAShader rendering

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8262293](https://bugs.openjdk.java.net/browse/JDK-8262293): Remove redundant end of encoder for AAShader rendering


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/202/head:pull/202`
`$ git checkout pull/202`
