### PR TITLE
8262729: Cleanup OpenGL references from Metal implementation

### DIFF
--- a/src/java.desktop/macosx/classes/sun/java2d/metal/MTLLayer.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/metal/MTLLayer.java
@@ -42,7 +42,7 @@ public class MTLLayer extends CFRetainedResource {
 
     // Pass the insets to native code to make adjustments in blitTexture
     private static native void nativeSetInsets(long layerPtr, int top, int left);
-    private static native void validate(long layerPtr, MTLSurfaceData cglsd);
+    private static native void validate(long layerPtr, MTLSurfaceData mtlsd);
     private static native void blitTexture(long layerPtr);
 
     private LWWindowPeer peer;
@@ -107,11 +107,11 @@ public class MTLLayer extends CFRetainedResource {
         return surfaceData;
     }
 
-    public void validate(final MTLSurfaceData cglsd) {
+    public void validate(final MTLSurfaceData mtlsd) {
         MTLRenderQueue rq = MTLRenderQueue.getInstance();
         rq.lock();
         try {
-            execute(ptr -> validate(ptr, cglsd));
+            execute(ptr -> validate(ptr, mtlsd));
         } finally {
             rq.unlock();
         }

--- a/src/java.desktop/macosx/classes/sun/java2d/metal/MTLSurfaceData.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/metal/MTLSurfaceData.java
@@ -613,15 +613,6 @@ public abstract class MTLSurfaceData extends SurfaceData
     }
 
 
-    // additional cleanup
-    private static native void destroyCGLContext(long ctx);
-
-    public static void destroyOGLContext(long ctx) {
-        if (ctx != 0L) {
-            destroyCGLContext(ctx);
-        }
-    }
-
     /**
      * Disposes the native resources associated with the given MTLSurfaceData
      * (referenced by the pData parameter).  This method is invoked from

--- a/src/java.desktop/macosx/classes/sun/java2d/metal/MTLSurfaceDataProxy.java
+++ b/src/java.desktop/macosx/classes/sun/java2d/metal/MTLSurfaceDataProxy.java
@@ -50,11 +50,11 @@ public class MTLSurfaceDataProxy extends SurfaceDataProxy {
         return new MTLSurfaceDataProxy(dstConfig, srcData.getTransparency());
     }
 
-    MTLGraphicsConfig oglgc;
+    MTLGraphicsConfig mtlgc;
     int transparency;
 
-    public MTLSurfaceDataProxy(MTLGraphicsConfig oglgc, int transparency) {
-        this.oglgc = oglgc;
+    public MTLSurfaceDataProxy(MTLGraphicsConfig mtlgc, int transparency) {
+        this.mtlgc = mtlgc;
         this.transparency = transparency;
     }
 
@@ -65,7 +65,7 @@ public class MTLSurfaceDataProxy extends SurfaceDataProxy {
     {
         if (cachedData == null) {
             try {
-                cachedData = oglgc.createManagedSurface(w, h, transparency);
+                cachedData = mtlgc.createManagedSurface(w, h, transparency);
             } catch (OutOfMemoryError er) {
                 return null;
             }

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
@@ -223,7 +223,7 @@ extern void initSamplers(id<MTLDevice> device);
         // initialize the surface as an MTLSD_WINDOW
         if (!MTLSD_InitMTLWindow(env, dstOps)) {
             J2dRlsTraceLn(J2D_TRACE_ERROR,
-                          "MTLContext_SetSurfaces: could not init OGL window");
+                          "MTLContext_SetSurfaces: could not init MTL window");
             return NULL;
         }
     }

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLSurfaceData.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLSurfaceData.m
@@ -378,11 +378,11 @@ Java_sun_java2d_metal_MTLSurfaceData_initOps
 
 JNIEXPORT void JNICALL
 Java_sun_java2d_metal_MTLSurfaceData_clearWindow
-(JNIEnv *env, jobject cglsd)
+(JNIEnv *env, jobject mtlsd)
 {
     J2dTraceLn(J2D_TRACE_INFO, "MTLSurfaceData_clearWindow");
 
-    BMTLSDOps *bmtlsdo = (MTLSDOps*) SurfaceData_GetOps(env, cglsd);
+    BMTLSDOps *bmtlsdo = (MTLSDOps*) SurfaceData_GetOps(env, mtlsd);
     MTLSDOps *mtlsdo = (MTLSDOps*) bmtlsdo->privOps;
 
     mtlsdo->peerData = NULL;


### PR DESCRIPTION
Cleaned up erroneous OpenGL references from Metal implementation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8262729](https://bugs.openjdk.java.net/browse/JDK-8262729): Cleanup OpenGL references from Metal implementation


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/206/head:pull/206`
`$ git checkout pull/206`
