### PR TITLE
8262882: Lanai: NetBeans crashes often when switching between dual and single screen

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBlitLoops.m
@@ -194,6 +194,9 @@ replaceTextureRegion(MTLContext *mtlc, id<MTLTexture> dest, const SurfaceDataRas
             [computeEncoder setBuffer:swizzled offset:0 atIndex:1];
 
             NSUInteger threadGroupSize = computePipelineState.maxTotalThreadsPerThreadgroup;
+            if (threadGroupSize == 0) {
+               threadGroupSize = 1;
+            }
             NSUInteger pixelCount = buff.length / srcInfo->pixelStride;
             MTLSize threadsPerGroup = MTLSizeMake(threadGroupSize, 1, 1);
             MTLSize threadGroups = MTLSizeMake((pixelCount + threadGroupSize - 1) / threadGroupSize,

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLContext.m
@@ -92,8 +92,13 @@ MTLTransform* tempTransform = nil;
     [self onComplete];
 
     [_pooledTextures release];
+    _pooledTextures = nil;
+
     [_commandBuffer release];
+    _commandBuffer = nil;
+
     [_lock release];
+    _lock = nil;
     [super dealloc];
 }
 
@@ -164,19 +169,54 @@ extern void initSamplers(id<MTLDevice> device);
 - (void)dealloc {
     J2dTraceLn(J2D_TRACE_INFO, "MTLContext.dealloc");
 
-    self.texturePool = nil;
+    // TODO : Check that texturePool is completely released.
+    // texturePool content is released in MTLCommandBufferWrapper.onComplete()
+    //self.texturePool = nil;
     self.vertexBuffer = nil;
     self.commandQueue = nil;
     self.blitCommandQueue = nil;
     self.pipelineStateStorage = nil;
-    [_encoderManager release];
-    [_samplerManager release];
-    [_stencilManager release];
-    [_composite release];
-    [_paint release];
-    [_transform release];
-    [_tempTransform release];
-    [_clip release];
+
+    if (_encoderManager != nil) {
+        [_encoderManager release];
+        _encoderManager = nil;
+    }
+
+    if (_samplerManager != nil) {
+        [_samplerManager release];
+        _samplerManager = nil;
+    }
+
+    if (_stencilManager != nil) {
+        [_stencilManager release];
+        _stencilManager = nil;
+    }
+
+    if (_composite != nil) {
+        [_composite release];
+        _composite = nil;
+    }
+
+    if (_paint != nil) {
+        [_paint release];
+        _paint = nil;
+    }
+
+    if (_transform != nil) {
+        [_transform release];
+        _transform = nil;
+    }
+
+    if (_tempTransform != nil) {
+        [_tempTransform release];
+        _tempTransform = nil;
+    }
+
+    if (_clip != nil) {
+        [_clip release];
+        _clip = nil;
+    }
+
     [super dealloc];
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderQueue.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLRenderQueue.m
@@ -656,14 +656,13 @@ Java_sun_java2d_metal_MTLRenderQueue_flushBuffer
                     CHECK_PREVIOUS_OP(MTL_OP_OTHER);
                     jlong pConfigInfo = NEXT_LONG(b);
                     CONTINUE_IF_NULL(mtlc);
-                    MTLGC_DestroyMTLGraphicsConfig(pConfigInfo);
 
-                    // the previous method will call glX/wglMakeCurrent(None),
-                    // so we should nullify the current mtlc and dstOps to avoid
-                    // calling glFlush() (or similar) while no context is current
                     if (mtlc != NULL) {
                         [mtlc.encoderManager endEncoder];
                     }
+
+                    MTLGC_DestroyMTLGraphicsConfig(pConfigInfo);
+
                     mtlc = NULL;
                  //   dstOps = NULL;
                     break;


### PR DESCRIPTION
Corrected MTLContext.dealloc() method to set released members to nil.
Setting texturePool member to nil causes double release as texturePool content gets released in MTLCommandBufferWrapper.onComplete() method as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8262882](https://bugs.openjdk.java.net/browse/JDK-8262882): Lanai: NetBeans crashes often when switching between dual and single screen


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/211/head:pull/211`
`$ git checkout pull/211`
