### PR TITLE
8259825: Find a better way to detect Metal framework availability on system

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLGraphicsConfig.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLGraphicsConfig.m
@@ -29,18 +29,9 @@
 #import "MTLSurfaceData.h"
 #import "ThreadUtilities.h"
 #import "awt.h"
-#import "MTLUtils.h"
-
-
-#import <stdlib.h>
-#import <string.h>
-#import <ApplicationServices/ApplicationServices.h>
 
 #pragma mark -
 #pragma mark "--- Mac OS X specific methods for Metal pipeline ---"
-
-// Uncomment this line to see Metal specific fprintfs
-//#define METAL_DEBUG
 
 /**
  * Disposes all memory and resources associated with the given
@@ -71,38 +62,16 @@ MTLGC_DestroyMTLGraphicsConfig(jlong pConfigInfo)
 #pragma mark "--- MTLGraphicsConfig methods ---"
 
 
-/**
- * Probe Metal framework availability using system profiler
- */
 JNIEXPORT jboolean JNICALL
 Java_sun_java2d_metal_MTLGraphicsConfig_isMetalFrameworkAvailable
     (JNIEnv *env, jclass mtlgc)
 {
-    FILE *f = popen("/usr/sbin/system_profiler SPDisplaysDataType", "r");
     jboolean metalSupported = JNI_FALSE;
-    while (getc(f) != EOF)
-    {
-        char str[60];
 
-        if (fgets(str, 60, f) != NULL) {
-            // Check for string
-            // "Metal:  Supported, feature set macOS GPUFamily1 v4"
-            if (strstr(str, "Metal") != NULL) {
-                //puts(str);
-                metalSupported = JNI_TRUE;
-                break;
-            }
-        }
+    // It is guranteed that metal supported GPU is available macOS 10.14 onwards
+    if (@available(macOS 10.14, *)) {
+        metalSupported = JNI_TRUE;
     }
-    pclose(f);
-
-#ifdef METAL_DEBUG
-    if (!metalSupported) {
-        fprintf(stderr, "Metal support not present\n");
-    } else {
-        fprintf(stderr, "Metal support is present\n");
-    }
-#endif
 
     J2dRlsTraceLn1(J2D_TRACE_INFO, "MTLGraphicsConfig_isMetalFrameworkAvailable : %d", metalSupported);
 


### PR DESCRIPTION
**Issue :** 
In Lanai code-base, system profiler command was used to detect Metal framework availability. This implementation although works as expected, is slower.

**Fix :** 
I have replaced the logic that was using system profiler command with @available check for macOS Mojave (10.14)

**More Info :** 
https://support.apple.com/en-us/HT205073 - mentions the HW that supports Metal framework. It is practically difficult to detect HW and then decide whether Metal framework is supported or not.
Instead, it is appropriate to check for OS version that guarantees Metal framework availability.
Please refer - https://support.apple.com/en-us/HT208898 - It is mentioned in the first line @ this link that "macOS Mojave requires a graphics card that supports Metal"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8259825](https://bugs.openjdk.java.net/browse/JDK-8259825): Find a better way to detect Metal framework availability on system


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/212/head:pull/212`
`$ git checkout pull/212`
