### PR TITLE
8263325: Lanai: clean RenderPerfTest/build.xml

### DIFF
--- a/test/jdk/performance/client/RenderPerfTest/build.xml
+++ b/test/jdk/performance/client/RenderPerfTest/build.xml
@@ -68,7 +68,7 @@
     <!-- Create the distribution directory -->
     <mkdir dir="${dist}"/>
 
-    <!-- Put everything in ${build} into the J2DBench.jar file -->
+    <!-- Put everything in ${build} into the RenderPerfTest.jar file -->
     <jar jarfile="${dist}/RenderPerfTest.jar" basedir="${build}">
       <manifest>
         <attribute name="Built-By" value="${user.name}"/>


### PR DESCRIPTION
Cleanup copy/paste error

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8263325](https://bugs.openjdk.java.net/browse/JDK-8263325): Lanai: clean RenderPerfTest/build.xml 


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/213/head:pull/213`
`$ git checkout pull/213`
