### PR TITLE
8263324: Lanai: use the PtrPixelsRow instead of multiplication

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBufImgOps.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLBufImgOps.m
@@ -175,13 +175,13 @@
         } else if (numBands == 3) {
             // user supplied band for each of R/G/B; alpha band is unused
             for (int i = 0; i < 3; i++) {
-                bands[i] = PtrAddBytes(tableValues, i*bandLength*bytesPerElem);
+                bands[i] = PtrPixelsBand(tableValues, i, bandLength, bytesPerElem);
             }
             bands[3] = NULL;
         } else if (numBands == 4) {
             // user supplied band for each of R/G/B/A
             for (int i = 0; i < 4; i++) {
-                bands[i] = PtrAddBytes(tableValues, i*bandLength*bytesPerElem);
+                bands[i] = PtrPixelsBand(tableValues, i, bandLength, bytesPerElem);
             }
         }
 

--- a/src/java.desktop/share/native/libawt/java2d/loops/GraphicsPrimitiveMgr.h
+++ b/src/java.desktop/share/native/libawt/java2d/loops/GraphicsPrimitiveMgr.h
@@ -485,6 +485,9 @@ extern struct _CompositeTypes {
 #define PtrPixelsRow(p, y, scanStride)    PtrAddBytes(p, \
     ((intptr_t) (y)) * (scanStride))
 
+#define PtrPixelsBand(p, y, length, elemSize)    PtrAddBytes(p, \
+    ((intptr_t) (y)) * (length) * (elemSize))
+
 /*
  * The function to call with an array of NativePrimitive structures
  * to register them with the Java GraphicsPrimitiveMgr.


### PR DESCRIPTION
Avoid multiplication in address arithmetics

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [JDK-8263324](https://bugs.openjdk.java.net/browse/JDK-8263324): Lanai: use the PtrPixelsRow instead of multiplication


### Download
`$ git fetch https://git.openjdk.java.net/lanai pull/214/head:pull/214`
`$ git checkout pull/214`
